### PR TITLE
Testcase to show a bug on insert() of a dao when having an insertpattern 

### DIFF
--- a/build/manifests/testapp.mn
+++ b/build/manifests/testapp.mn
@@ -188,6 +188,7 @@ cd testapp/modules/jelix_tests/daos
   products.dao.xml
   products_events.dao.xml
   product_tags.dao.xml
+  labels_insertpattern.dao.xml
   description.dao.xml
   labels.dao.xml
   labels1.dao.xml

--- a/testapp/modules/jelix_tests/daos/labels_insertpattern.dao.xml
+++ b/testapp/modules/jelix_tests/daos/labels_insertpattern.dao.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<dao xmlns="http://jelix.org/ns/dao/1.0">
+   <datasources>
+      <primarytable name="labels_test" primarykey="key,lang" />
+   </datasources>
+   <record>
+      <property name="key"   fieldname="key" datatype="int"/>
+      <property name="lang"  fieldname="lang" datatype="string" insertpattern="YEAR(NOW())"/>
+      <property name="keyalias"  fieldname="keyalias" datatype="string"/>
+      <property name="label" fieldname="label" datatype="string"  required="true" insertpattern="YEAR(NOW())"/>
+   </record>
+   <factory>
+   </factory>
+</dao>
+

--- a/testapp/modules/jelix_tests/tests/jdao.main_api.html_cli.php
+++ b/testapp/modules/jelix_tests/tests/jdao.main_api.html_cli.php
@@ -16,6 +16,7 @@ class UTDao extends jUnitTestCaseDb {
 
     function testStart() {
         $this->emptyTable('product_test');
+        $this->emptyTable('labels_test');
     }
 
     function testInstanciation() {
@@ -122,6 +123,32 @@ class UTDao extends jUnitTestCaseDb {
         $this->assertTableContainsRecords('product_test', $this->records);
 
     }
+
+    protected $labelsIP1;
+    protected $recordsLabelIP;
+
+
+    function testInsertpatternOnPk() {
+        $dao = jDao::create ('labels_insertpattern');
+
+        $this->labelsIP1 = jDao::createRecord ('labels_insertpattern');
+        $this->labelsIP1->key = 1;
+        $this->labelsIP1->keyalias = 'alias';
+        $res = $dao->insert($this->labelsIP1);
+
+        $this->assertEqual($res, 1, 'jDaoBase::insert does not return 1');
+
+        $this->recordsLabelIP = array(
+            array('key'=>$this->labelsIP1->key,
+            'lang'=>date('Y'),
+            'keyalias'=>$this->labelsIP1->keyalias,
+            'label'=>date('Y'),
+           )
+        );
+        $this->assertTableContainsRecords('labels_test', $this->recordsLabelIP);
+
+    }
+
 
     function testGet() {
         $dao = jDao::create ('products');


### PR DESCRIPTION
Dirty testcase to show a bug on insert() of a dao when having an insertpattern on a PK and on a regular field.

This is for Trac ticket #1436.
