### PR TITLE
jApp::coord() return null 

### DIFF
--- a/lib/jelix/core/jCoordinator.class.php
+++ b/lib/jelix/core/jCoordinator.class.php
@@ -85,6 +85,9 @@ class jCoordinator {
 
         // temporary init. Remove this line when JELIX_APP_* and $gJConfig support will be removed completely from Jelix
         jApp::initLegacy();
+        
+        #    fix
+		jApp::setCoord($this);
 
         $this->_loadPlugins();
     }


### PR DESCRIPTION
En essayant la derniere version nightly j'Ai eu cette erreur. Je l'ai corrigé

Fatal error: Call to a member function handleError() on a non-object in C:\RND\projects\top\Hitnote\app\lib\jelix\core\jErrorHandler.lib.php on line 63
