### PR TITLE
Modification de la valeur d'un argument dans pg_fetch_object pour Php 5.4

### DIFF
--- a/lib/jelix/plugins/db/pgsql/pgsql.dbresultset.php
+++ b/lib/jelix/plugins/db/pgsql/pgsql.dbresultset.php
@@ -31,9 +31,9 @@ class pgsqlDbResultSet extends jDbResultSet {
     public function fetch() {
         if ($this->_fetchMode == jDbConnection::FETCH_CLASS) {
             if ($this->_fetchModeCtoArgs)
-                $res = pg_fetch_object ($this->_idResult, -1 , $this->_fetchModeParam, $this->_fetchModeCtoArgs);
+                $res = pg_fetch_object ($this->_idResult, null , $this->_fetchModeParam, $this->_fetchModeCtoArgs);
             else
-                $res = pg_fetch_object ($this->_idResult, -1 , $this->_fetchModeParam);
+                $res = pg_fetch_object ($this->_idResult, null , $this->_fetchModeParam);
         }
         else if ($this->_fetchMode == jDbConnection::FETCH_INTO) {
              $res = pg_fetch_object ($this->_idResult);


### PR DESCRIPTION
Depuis la migration vers Php 5.4, plus aucune donnée n'était renvoyé par Postrgresql, les logs renvoyant la notice : "The row parameter must be greater or equal to zero"
La doc de php indique que l'argument $row de pg_fetch_object doit être null si on ne l'utilise pas, en passant de -1 a null, tout refonctionne...

Note: En version Php 5.3.10, tout fonctionnait normalement (pour exactement la même configuration), même avec l'argument de pg_fetch_object à -1
