### PR TITLE
jRequest::getPort add an ulimate check to $port var to prevent function ...

### DIFF
--- a/lib/jelix/core/jRequest.class.php
+++ b/lib/jelix/core/jRequest.class.php
@@ -338,7 +338,7 @@ abstract class jRequest {
       } else {
          $port = $_SERVER['SERVER_PORT'];
       }
-      if (($https && $port == '443' ) || (!$https && $port == '80' ))
+      if (($port === NULL) || ($port == '') || ($https && $port == '443' ) || (!$https && $port == '80' ))
          return '';
       return ':'.$port;
    }


### PR DESCRIPTION
...from returning ':' alone
