### PR TITLE
Add unknown attribute check in dao property

### DIFF
--- a/lib/jelix/core-modules/jelix/locales/en_EN/daoxml.UTF-8.properties
+++ b/lib/jelix/core-modules/jelix/locales/en_EN/daoxml.UTF-8.properties
@@ -3,11 +3,12 @@
 file.unknown= (510)unknown dao file (%s)
 namespace.wrong= (511)bad namespace in the DAO file "%s" (%s)
 
-missing.attr=(512)DAO %1$s, Attribut "%3$s" is missing on tag "%4$s" (file %2$s)
+missing.attr=(512)DAO %1$s, attribute "%3$s" is missing on tag "%4$s" (file %2$s)
 tag.duplicate = (513)DAO %1$s, only one %3$s tag is allowed in the %4$s method (file %2$s)
 forbidden.attr=(514)DAO %1$s, the "%3$s" attribute is not allowed on the "%4$s" element (file %2$s)
 forbidden.attr.context=(515)DAO %1$s, the "%3$s" attribute is not allowed on the "%4$s" element in this context (file %2$s)
 wrong.attr=(516)DAO %1$s, the value "%3$s" of the "%4$s" attribute on the "%5$s" element is not valid (file %2$s)
+unknown.attr=(517)DAO %1$s, attribute "%3$s" is unknown on tag "%4$s" (file %2$s)
 
 datasource.missing= (520)DAO %1$s, table is missing (file %2$s)
 table.two.many= (521)DAO %1$s, too much table (file %2$s)

--- a/lib/jelix/core-modules/jelix/locales/en_US/daoxml.UTF-8.properties
+++ b/lib/jelix/core-modules/jelix/locales/en_US/daoxml.UTF-8.properties
@@ -3,11 +3,12 @@
 file.unknown= (510)Unknown dao file (%s)
 namespace.wrong= (511)bad namespace in the DAO file "%s" (%s)
 
-missing.attr=(512)DAO %1$s, Attribut "%3$s" is missing on tag "%4$s" (file %2$s)
+missing.attr=(512)DAO %1$s, attribute "%3$s" is missing on tag "%4$s" (file %2$s)
 tag.duplicate = (513)DAO %1$s, only one %3$s tag is allowed in the %4$s method (file %2$s)
 forbidden.attr=(514)DAO %1$s, the "%3$s" attribute is not allowed on the "%4$s" element (file %2$s)
 forbidden.attr.context=(515)DAO %1$s, the "%3$s" attribute is not allowed on the "%4$s" element in this context (file %2$s)
 wrong.attr=(516)DAO %1$s, the value "%3$s" of the "%4$s" attribute on the "%5$s" element is not valid (file %2$s)
+unknown.attr=(517)DAO %1$s, attribute "%3$s" is unknown on tag "%4$s" (file %2$s)
 
 datasource.missing= (520)DAO %1$s, table is missing (file %2$s)
 table.two.many= (521)DAO %1$s, too much table (file %2$s)

--- a/lib/jelix/core-modules/jelix/locales/fr_FR/daoxml.UTF-8.properties
+++ b/lib/jelix/core-modules/jelix/locales/fr_FR/daoxml.UTF-8.properties
@@ -3,11 +3,12 @@
 file.unknown= (510)Fichier de définition de DAO (%s) introuvable ou invalide
 namespace.wrong= (511)Le document "%s" n'est pas un dao ou l'espace de nom xml est invalide (%s)
 
-missing.attr=(512)DAO %1$s,Attribut "%3$s" obligatoire dans une balise "%4$s" (fichier %2$s)
+missing.attr=(512)DAO %1$s, attribut "%3$s" obligatoire dans une balise "%4$s" (fichier %2$s)
 tag.duplicate = (513)DAO %1$s, une seule balise %3$s est permise dans la méthode %4$s (fichier %2$s)
 forbidden.attr=(514)DAO %1$s, l'attribut "%3$s" n'est pas autorisé sur la balise "%4$s" (fichier %2$s)
 forbidden.attr.context=(515)DAO %1$s, l'attribut "%3$s" n'est pas autorisé dans ce context sur la balise "%4$s" (fichier %2$s)
 wrong.attr=(516)DAO %1$s, la valeur "%3$s" de l'attribut "%4$s" sur la balise "%5$s" n'est pas valide (fichier %2$s)
+unknown.attr=(517)DAO %1$s, attribut "%3$s" inconnu dans la balise "%4$s" (fichier %2$s)
 
 datasource.missing= (520)DAO %1$s, une table doit être indiquée (fichier %2$s)
 table.two.many= (521)DAO %1$s, trop de tables définies (fichier %2$s)

--- a/lib/jelix/dao/jDaoProperty.class.php
+++ b/lib/jelix/dao/jDaoProperty.class.php
@@ -4,6 +4,7 @@
 * @subpackage  dao
 * @author      Gérald Croes, Laurent Jouanneau
 * @contributor Laurent Jouanneau
+* @contributor Philippe Villiers
 * @copyright   2001-2005 CopixTeam, 2005-2011 Laurent Jouanneau
 * This class was get originally from the Copix project (CopixDAODefinitionV1, Copix 2.3dev20050901, http://www.copix.org)
 * Few lines of code are still copyrighted 2001-2005 CopixTeam (LGPL licence).
@@ -91,7 +92,18 @@ class jDaoProperty {
     */
     function __construct ($aAttributes, $parser, $tools){
         $needed = array('name', 'fieldname', 'table', 'datatype', 'required',
-                        'minlength', 'maxlength', 'regexp', 'sequence', 'default','autoincrement');
+                        'minlength', 'maxlength', 'regexp', 'sequence', 'default', 'autoincrement');
+
+        // Allowed attributes names
+        $allowed = array('name', 'fieldname', 'table', 'datatype', 'required',
+                        'minlength', 'maxlength', 'regexp', 'sequence', 'default', 'autoincrement',
+                        'updatepattern', 'insertpattern', 'selectpattern');
+
+        foreach($aAttributes as $attributeName => $attributeValue) {
+            if(!in_array($attributeName, $allowed)) {
+                throw new jDaoXmlException ($parser->selector, 'unknown.attr', array($attributeName, 'property'));
+            }
+        }
 
         $params = $parser->getAttr($aAttributes, $needed);
 


### PR DESCRIPTION
This is to avoid mistakes such as typos in attributes names (such as "inserpattern" instead of "insertpattern", which failed silently)
