### PR TITLE
mysqli driver should now work also with mysql module, not just mysqlnd

### DIFF
--- a/lib/jelix/plugins/db/mysqli/mysqli.dbconnection.php
+++ b/lib/jelix/plugins/db/mysqli/mysqli.dbconnection.php
@@ -23,6 +23,7 @@ require_once(dirname(__FILE__).'/mysqli.dbstatement.php');
 class mysqliDbConnection extends jDbConnection {
 
     protected $_charsets =array( 'UTF-8'=>'utf8', 'ISO-8859-1'=>'latin1');
+    private $_usesMysqlnd = true;
 
     function __construct($profile){
         // à cause du @, on est obligé de tester l'existence de mysql, sinon en cas d'absence
@@ -72,7 +73,7 @@ class mysqliDbConnection extends jDbConnection {
     public function prepare ($query){
         $res = $this->_connection->prepare($query);
         if($res){
-            $rs= new mysqliDbStatement($res);
+            $rs= new mysqliDbStatement($res, $this->_usesMysqlnd);
         }else{
             throw new jException('jelix~db.error.query.bad',  $this->_connection->error.'('.$query.')');
         }
@@ -97,6 +98,11 @@ class mysqliDbConnection extends jDbConnection {
             if(isset($this->profile['force_encoding']) && $this->profile['force_encoding'] == true
               && isset($this->_charsets[jApp::config()->charset])){
                 $cnx->set_charset($this->_charsets[jApp::config()->charset]);
+            }
+            if( is_callable( array($cnx, 'get_result') ) ) {
+                $this->_usesMysqlnd = true;
+            } else {
+                $this->_usesMysqlnd = false;
             }
             return $cnx;
         }

--- a/lib/jelix/plugins/db/mysqli/mysqli.dbresultset.php
+++ b/lib/jelix/plugins/db/mysqli/mysqli.dbresultset.php
@@ -31,7 +31,8 @@ class mysqliDbResultSet extends jDbResultSet {
     }
 
     protected function _free (){
-        return $this->_idResult->close();
+        //free_result may lead to a warning if close() has been called before by dbconnection's _disconnect()
+        return @$this->_idResult->free_result();
     }
 
     protected function _rewind (){


### PR DESCRIPTION
...even though mysqlnd should stay the best one, for memory consumption reasons.

I also fixed an issue (to my mind) which is calling free_results() instead of close() when dbresults' _free() is called.

It should be noted that I only tested with testapp's mysqli unit tests. Not in real life.
