### PR TITLE
Remove a dependancy of testapp to php's gd module.

### DIFF
--- a/testapp/modules/jelix_tests/tests/jcache.lib.php
+++ b/testapp/modules/jelix_tests/tests/jcache.lib.php
@@ -40,7 +40,7 @@ abstract class UTjCacheAPI extends jUnitTestCaseDb {
             'content'=>'Lorem ipsum dolor sit amét, conséctetuer adipiscing elit. Donec at odio vitae libero tempus convallis. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Vestibulum purus mauris, dapibus eu, sagittis quis, sagittis quis, mi. Morbi fringilla massa quis velit. Curabitur metus massa, semper mollis, molestie vel, adipiscing nec, massa. Phasellus vitae felis sed lectus dapibus facilisis. In ultrices sagittis ipsum. In at est. Integer iaculis turpis vel magna. Cras eu est. Integer porttitor ligula a tellus. Curabitur accumsan ipsum a velit. Sed laoreet lectus quis leo. Nulla pellentesque molestie ante. Quisque vestibulum est id justo. Ut pellentesque ante in neque.'
         );
         $myObj=(object)array('property1'=>'string','property2'=>'integer');
-        $img=@imagecreate(100,100);
+        $tmpFile = tmpfile();
 
         $this->assertFalse(jCache::set('defaultProfileDisabledKey',$myData));
 
@@ -64,7 +64,8 @@ abstract class UTjCacheAPI extends jUnitTestCaseDb {
             $this->pass();
         }
 
-        $this->assertFalse(jCache::set('unableToSerializeDataKey',$img,0,$this->profile));
+        $this->assertFalse(jCache::set('unableToSerializeDataKey',$tmpFile,0,$this->profile));
+        fclose( $tmpFile );
     }
 
     public function testGet (){


### PR DESCRIPTION
If gd was missing, there was a silent (because of @) crash of testapp because of missing imagecreate() function. Now using tmpfile() instead : it returns a ressource too and should not need any special module.

Hope this is better.

jCache tests still pass on my machine.
