### PR TITLE
Commit 1881989619 did fixed an issue introduced by commit 7999de8605, bu...

### DIFF
--- a/lib/jelix/core/jConfigCompiler.class.php
+++ b/lib/jelix/core/jConfigCompiler.class.php
@@ -377,11 +377,11 @@ class jConfigCompiler {
                         }
                         elseif ($config->modules[$f.'.access']) {
                             $config->_modulesPathList[$f]=$p.$f.'/';
-                            self::readModuleFile($config, $p.$f.'/');
                             if (file_exists( $p.$f.'/plugins')) {
                                 $config->pluginsPath .= ',module:'.$f;
                             }
                         }
+                        self::readModuleFile($config, $p.$f.'/');
                     }
                 }
                 closedir($handle);


### PR DESCRIPTION
...t previous code was poorly indented and thus it leaded to mis-reading.

I did have a problem loading testapp's PHP tests which leaded to a crash : PHP Fatal error:  Class 'jAclDbUserGroup' not found in ...testapp/modules/jelix_tests/tests/jacl.main_api.html_cli.php .
I do not understand clearly the problem, but this solves the issue and seems to be keeping the behaviour before commit 7999de8605 while preserving its enhancements
