### PR TITLE
Testapp tests for jforms' datasources was based on the order of rows from some SQL queries

### DIFF
--- a/testapp/modules/jelix_tests/daos/labels.dao.xml
+++ b/testapp/modules/jelix_tests/daos/labels.dao.xml
@@ -10,6 +10,13 @@
       <property name="label" fieldname="label" datatype="string"  required="true"/>
    </record>
    <factory>
+      <method name="findAllOrderByKeyalias">
+          <order>
+              <orderitem property="keyalias" way="asc" />
+          </order>
+      </method>
+
+
       <method name="findByLang">
          <parameter name="lang" />
          <conditions>
@@ -35,13 +42,16 @@
       </method>
 
 
-      <method name="findByLang2">
+      <method name="findByLang2OrderByKeyalias">
          <parameter name="lang1" />
          <parameter name="lang2" />
          <conditions logic="or">
             <eq property="lang" expr="$lang1" />
             <eq property="lang" expr="$lang2" />
          </conditions>
+          <order>
+              <orderitem property="keyalias" way="asc" />
+          </order>
       </method>
 
       <method name="findByLang3">

--- a/testapp/modules/jelix_tests/tests/jforms.datasources.html_cli.php
+++ b/testapp/modules/jelix_tests/tests/jforms.datasources.html_cli.php
@@ -199,7 +199,7 @@ class UTjformsDatasources extends jUnitTestCaseDb {
         $form = jForms::get('product');
 
         // ---- retrieve data
-        $ds = new jFormsDaoDatasource('jelix_tests~labels' , "findAll" , 'label', 'key', '');
+        $ds = new jFormsDaoDatasource('jelix_tests~labels' , "findAllOrderByKeyalias" , 'label', 'key', '');
         $data = $ds->getData($form);
         $this->assertEqual($data, array('1'=>'dd-en', '2'=>'ee-en', '3'=>'cc-fr'));
         try {
@@ -211,7 +211,7 @@ class UTjformsDatasources extends jUnitTestCaseDb {
         }
 
         // ---- retrieve data with multiple label
-        $ds = new jFormsDaoDatasource('jelix_tests~labels' , "findAll" , 'lang,label', 'key', '', null, null, '#');
+        $ds = new jFormsDaoDatasource('jelix_tests~labels' , "findAllOrderByKeyalias" , 'lang,label', 'key', '', null, null, '#');
         $data = $ds->getData($form);
         $this->assertEqual($data, array('1'=>'en#dd-en', '2'=>'en#ee-en', '3'=>'fr#cc-fr'));
     }
@@ -235,7 +235,7 @@ class UTjformsDatasources extends jUnitTestCaseDb {
         //$data = $ds->getData($form);
         //$this->assertError();
 
-        $ds = new jFormsDaoDatasource('jelix_tests~labels' , "findByLang2" , 'label', 'key', '', "fr,en");
+        $ds = new jFormsDaoDatasource('jelix_tests~labels' , "findByLang2OrderByKeyalias" , 'label', 'key', '', "fr,en");
         $ds->labelMethod = 'getByLang2';
         $data = $ds->getData($form);
         $this->assertEqual($data, array('1'=>'dd-en', '2'=>'ee-en', '3'=>'cc-fr'));


### PR DESCRIPTION
But there was no ORDER clause for those queries, so the order on the output was non-deterlinistic and senstive to previous insert/commits on that table. Used existing keyalias field and its existing values to get that order determined.
