### PR TITLE
Add quotes escaping in patterns.

### DIFF
--- a/lib/jelix/dao/jDaoGenerator.class.php
+++ b/lib/jelix/dao/jDaoGenerator.class.php
@@ -836,7 +836,11 @@ class jDaoGenerator {
             $value = $this->_preparePHPExpr('$'.$prefixfield.$fieldName, $field, true);
 
             if($pattern != ''){
-                $values[$field->name] = sprintf($field->$pattern,'\'.'.$value.'.\'');
+                if(strpos($field->$pattern, "'") !== false) {
+                    $values[$field->name] = sprintf(str_replace("'", "\\'", $field->$pattern),'\'.'.$value.'.\'');
+                } else {
+                    $values[$field->name] = sprintf($field->$pattern,'\'.'.$value.'.\'');
+                }
             }else{
                 $values[$field->name] = '\'.'.$value.'.\'';
             }


### PR DESCRIPTION
This allows patterns such as TO_DATE(%s, 'YYYY-MM-DD HH24:MI:SS') to work correctly in generated DAO files, instead of having a parse error :P

Can also be applied to 1.4.x and master branches.
