### PR TITLE
Renaming jSelectorDaoRecord type: dao => daorecord

### DIFF
--- a/lib/jelix/core/selector/jSelectorDaoRecord.class.php
+++ b/lib/jelix/core/selector/jSelectorDaoRecord.class.php
@@ -18,7 +18,7 @@
  */
 
 class jSelectorDaoRecord extends jSelectorModule {
-    protected $type = 'dao';
+    protected $type = 'daorecord';
     protected $_dirname = 'daos/';
     protected $_suffix = '.daorecord.php';
 


### PR DESCRIPTION
When DaoRecord extended object missing:

> The selector "myapp~mymodule" doesn't correspond to a resource of type : "dao"

so I just switched the  jSelectorDaoRecord type to "daorecord"
