### PR TITLE
jUrl::getCurrentUrl() : prevent a trailing '?'

### DIFF
--- a/lib/jelix/core/jUrl.class.php
+++ b/lib/jelix/core/jUrl.class.php
@@ -119,11 +119,13 @@ class jUrl extends jUrlBase {
         static $url = false;
         if ($url === false){
             $req = jApp::coord()->request;
-            $url = $req->getServerURI().$req->urlScript.$req->urlPathInfo.'?';
+            $url = $req->getServerURI().$req->urlScript.$req->urlPathInfo;
             $q = http_build_query($_GET, '', ($forxml?'&amp;':'&'));
             if(strpos($q, '%3A')!==false)
                 $q = str_replace( '%3A', ':', $q);
-            $url .=$q;
+            if( $q != '' ) {
+                $url .= '?' . $q;
+            }
         }
         return $url;
     }


### PR DESCRIPTION
When there is nothing in the $_GET, there should be no '?' at the end of the url ...
