### PR TITLE
autoload will fail because of multiple entry points and cDaoRecord in session

### DIFF
--- a/lib/jelix/init.php
+++ b/lib/jelix/init.php
@@ -152,6 +152,10 @@ function jelix_autoload($class) {
     }
     elseif(preg_match('/^cDao(?:Record)?_(.+)_Jx_(.+)_Jx_(.+)$/', $class, $m)){
         // for DAO which are stored in sessions for example
+        if(!isset(jApp::config()->_modulesPathList[$m[1]])){
+            //this may happen if we have several entry points, but the current one does not have this module accessible
+            return;
+        }
         $s = new jSelectorDao($m[1].'~'.$m[2], $m[3], false);
         if(jApp::config()->compilation['checkCacheFiletime']){
             // if it is needed to check the filetime, then we use jIncluder


### PR DESCRIPTION
Test case with Jelix 1.4.0 (I suppose it concerns 1.5 too) :
- create an app
- create an admin entry point (while keeping index)
- create an "account" module only for the index entry point (with -ep option)
- install jauth
- put a dao for your user table in the account module and use that dao in jauth config (account~user)
- configure it so that you can connect (e.g. using an existing Db, with the same settings : crypt functions and so on)
- with a browser, access the index entry point
- connect with a valid login / password. We don't care if the landing page does not work
- access the admin entry point with the same browser and keeping your session

The last point crashes because, as far as I understand, there is an autoload done according to cDaoRecords found in session (this is done in lib/jelix/init.php, in jelix_autoload() function).

Here is my trace :

```
2012-10-18 14:51:00 127.0.0.1   error   2012-10-18 14:51:00 127.0.0.1   [18]    Unknown module in the selector "account~user"   /var/www/test_autoload/jelix-1.4-dev/lib/jelix/core/selector/jSelectorDao.class.php 48
/test_autoload/jelix-1.4-dev/testAL/www/admin.php
array ( )

0   jSelectorDao->_createPath() /var/www/test_autoload/jelix-1.4-dev/lib/jelix/core/selector/jSelectorModule.class.php : 44
1   jSelectorModule->__construct()  /var/www/test_autoload/jelix-1.4-dev/lib/jelix/core/selector/jSelectorDao.class.php : 42
2   jSelectorDao->__construct() /var/www/test_autoload/jelix-1.4-dev/lib/jelix/init.php : 117
3   jelix_autoload()    [php] : 
4   spl_autoload_call() [php] : 
5   session_start() /var/www/test_autoload/jelix-1.4-dev/lib/jelix/core/jSession.class.php : 81
6   jSession::start()   /var/www/test_autoload/jelix-1.4-dev/lib/jelix/core/jCoordinator.class.php : 135
7   jCoordinator->process() /var/www/test_autoload/jelix-1.4-dev/testAL/www/admin.php : 19
```
