### PR TITLE
Load coordinator plugin with include once, not include in _loadPlugins

### DIFF
--- a/lib/jelix/core/jCoordinator.class.php
+++ b/lib/jelix/core/jCoordinator.class.php
@@ -101,7 +101,7 @@ class jCoordinator {
                 if (false === ($conf = parse_ini_file($conff,true)))
                     throw new Exception("Error in a plugin configuration file -- plugin: $name  file: $conff", 13);
             }
-            include( $config->_pluginsPathList_coord[$name].$name.'.coord.php');
+            include_once($config->_pluginsPathList_coord[$name].$name.'.coord.php');
             $class= $name.'CoordPlugin';
             $this->plugins[strtolower($name)] = new $class($conf);
         }


### PR DESCRIPTION
Dans le cas ou on souhaite changer de contexte / point d'entrée, c'est indispensable.
