### PR TITLE
asked by Laurent: Method to get resource list in jacl2rights.dao.xml.

### DIFF
--- a/lib/jelix-modules/jacl2db/daos/jacl2rights.dao.xml
+++ b/lib/jelix-modules/jacl2db/daos/jacl2rights.dao.xml
@@ -33,6 +33,15 @@
                 <eq property="id_aclgrp" expr="$group" />
             </conditions>
         </method>
+        <method name="getResByRightByGroup" type="select">
+            <parameter name="group" />
+            <parameter name="subject" />
+            <conditions >
+                <eq property="id_aclsbj" expr="$subject" />
+                <eq property="id_aclgrp" expr="$group" />
+                <neq property="id_aclres" value="-" />
+            </conditions>
+        </method>
         <method name="getRightWithRes" type="selectfirst">
            <parameter name="subject" />
            <parameter name="groups" />


### PR DESCRIPTION
Method to get resource list in jacl2rights.dao.xml.
Laurent asked me to add it, so here it is
Method name="getResByRightByGroup"
