### PR TITLE
Add pattern in conditions, like the (select|insert|update)pattern.

### DIFF
--- a/lib/jelix/dao/jDaoConditions.class.php
+++ b/lib/jelix/dao/jDaoConditions.class.php
@@ -3,10 +3,11 @@
 * @package    jelix
 * @subpackage dao
 * @author     Gérald Croes, Laurent Jouanneau
-* @contributor Laurent Jouanneau, Julien Issler, Yannick Le Guédart
+* @contributor Laurent Jouanneau, Julien Issler, Yannick Le Guédart, Philippe Villiers
 * @copyright  2001-2005 CopixTeam, 2005-2009 Laurent Jouanneau
 * @copyright  2008 Thomas
 * @copyright  2008 Julien Issler, 2009 Yannick Le Guédart
+* @copyright  2013 Philippe Villiers
 * This classes was get originally from the Copix project (CopixDAOSearchConditions, Copix 2.3dev20050901, http://www.copix.org)
 * Some lines of code are copyrighted 2001-2005 CopixTeam (LGPL licence).
 * Initial authors of this Copix classes are Gerald Croes and Laurent Jouanneau,
@@ -149,9 +150,10 @@ class jDaoConditions {
     * @param string $field_id  the property name on which the condition applies
     * @param string $operator  the sql operator
     * @param string $value     the value which is compared to the property
+    * @param string $field_pattern  the pattern to use on the property (WHERE clause)
     * @param boolean $foo      parameter for internal use : don't use it or set to false
     */
-    function addCondition ($field_id, $operator, $value, $foo = false){
+    function addCondition ($field_id, $operator, $value, $field_pattern = '%s', $foo = false){
         $operator = trim(strtoupper($operator));
         if(preg_match ('/^[^\w\d\s;\(\)]+$/', $operator) ||
            in_array($operator, array('LIKE', 'NOT LIKE', 'ILIKE', 'IN', 'NOT IN', 'IS', 'IS NOT', 'IS NULL',
@@ -159,6 +161,7 @@ class jDaoConditions {
 
             $this->_currentCondition->conditions[] = array (
                'field_id'=>$field_id,
+               'field_pattern'=>$field_pattern,
                'value'=>$value,
                'operator'=>$operator, 'isExpr'=>$foo);
         }

--- a/lib/jelix/dao/jDaoGenerator.class.php
+++ b/lib/jelix/dao/jDaoGenerator.class.php
@@ -6,8 +6,10 @@
 * @contributor Laurent Jouanneau
 * @contributor Bastien Jaillot (bug fix)
 * @contributor Julien Issler, Guillaume Dugas
+* @contributor Philippe Villiers
 * @copyright  2001-2005 CopixTeam, 2005-2012 Laurent Jouanneau
 * @copyright  2007-2008 Julien Issler
+* @copyright  2013 Philippe Villiers
 * This class was get originally from the Copix project (CopixDAOGeneratorV1, Copix 2.3dev20050901, http://www.copix.org)
 * Few lines of code are still copyrighted 2001-2005 CopixTeam (LGPL licence).
 * Initial authors of this Copix class are Gerald Croes and Laurent Jouanneau,
@@ -938,10 +940,20 @@ class jDaoGenerator {
 
             $prop = $fields[$cond['field_id']];
 
+            $pattern = (isset($cond['field_pattern']) && !empty($cond['field_pattern'])) ? $cond['field_pattern'] : '%s';
+
             if($withPrefix){
-                $f = $this->_encloseName($prop->table).'.'.$this->_encloseName($prop->fieldName);
+				if($pattern == '%s') {
+					$f = $this->_encloseName($prop->table).'.'.$this->_encloseName($prop->fieldName);
+				} else {
+					$f = str_replace(array("'", "%s"), array("\\'", $this->_encloseName($prop->table).'.'.$this->_encloseName($prop->fieldName)), $pattern);
+				}
             }else{
-                $f = $this->_encloseName($prop->fieldName);
+				if($pattern == '%s') {
+					$f = $this->_encloseName($prop->fieldName);
+				} else {
+					$f = str_replace(array("'", "%s"), array("\\'", $this->_encloseName($prop->fieldName)), $pattern);
+				}
             }
 
             $r .= $f.' ';

--- a/lib/jelix/dao/jDaoMethod.class.php
+++ b/lib/jelix/dao/jDaoMethod.class.php
@@ -5,7 +5,8 @@
 * @author      Gérald Croes, Laurent Jouanneau
 * @contributor Laurent Jouanneau
 * @contributor Olivier Demah
-* @copyright   2001-2005 CopixTeam, 2005-2009 Laurent Jouanneau, 2010 Olivier Demah
+* @contributor Philippe Villiers
+* @copyright   2001-2005 CopixTeam, 2005-2009 Laurent Jouanneau, 2010 Olivier Demah, 2013 Philippe Villiers
 * This class was get originally from the Copix project (CopixDAODefinitionV1, Copix 2.3dev20050901, http://www.copix.org)
 * Few lines of code are still copyrighted 2001-2005 CopixTeam (LGPL licence).
 * Initial authors of this Copix class are Gerald Croes and Laurent Jouanneau,
@@ -201,7 +202,7 @@ class jDaoMethod {
         'binary_op'=>'dummy');
       // 'between'=>'BETWEEN',  'notbetween'=>'NOT BETWEEN',
 
-    private $_attrcond = array('property', 'expr', 'operator', 'driver'); //, 'min', 'max', 'exprmin', 'exprmax'
+    private $_attrcond = array('property', 'pattern', 'expr', 'operator', 'driver'); //, 'min', 'max', 'exprmin', 'exprmax'
 
     private function _addCondition($op, $cond){
 
@@ -220,6 +221,8 @@ class jDaoMethod {
         if (!isset ($props[$field_id])){
             throw new jDaoXmlException ($this->_parser->selector, 'method.property.unknown', array($this->name, $field_id));
         }
+
+        $field_pattern = ($attr['pattern']!==null? $attr['pattern']:'');
 
         if($this->type=='update'){
             if($props[$field_id]->table != $this->_parser->getPrimaryTable()){
@@ -249,7 +252,7 @@ class jDaoMethod {
                 }
                 $operator = $attr['operator'];
             }
-            $this->_conditions->addCondition ($field_id, $operator, $value);
+            $this->_conditions->addCondition ($field_id, $operator, $value, $field_pattern);
         }else if($attr['expr']!==null){
             if($op == 'isnull' || $op =='isnotnull'){
                 throw new jDaoXmlException ($this->_parser->selector, 'method.condition.valueexpr.notallowed', array($this->name, $op, $field_id));
@@ -268,12 +271,12 @@ class jDaoMethod {
                 }
                 $operator = $attr['operator'];
             }
-            $this->_conditions->addCondition ($field_id, $operator, $attr['expr'], true);
+            $this->_conditions->addCondition ($field_id, $operator, $attr['expr'], $field_pattern, true);
         }else{
             if($op != 'isnull' && $op !='isnotnull'){
                 throw new jDaoXmlException ($this->_parser->selector, 'method.condition.valueexpr.missing', array($this->name, $op, $field_id));
             }
-            $this->_conditions->addCondition ($field_id, $operator, '', false);
+            $this->_conditions->addCondition ($field_id, $operator, '', $field_pattern, false);
         }
     }
 


### PR DESCRIPTION
Related to issue #122, it adds the ability to specify a pattern in conditions, to be able to use SQL operators such as UPPER() in where close of those conditions.
For example,

``` xml
<eq property="column" pattern="UPPER(%s)" value="A_VALUE" />
```

would build a query like this

``` sql
[...] WHERE UPPER(column) = 'A_VALUE' [...]
```

This also adds a $pattern parameter at the end of the jDao::addCondition() method, for backwards compatibility, so this change should be compatible with Jelix 1.3 and earlier.

The second part (tests update) will be coming soon, but I don't know how to setup the tests correctly exactly.
