### PR TITLE
Update lib/jelix-modules/jpref/classes/jPrefManager.php

### DIFF
--- a/lib/jelix-modules/jpref/classes/jPrefManager.php
+++ b/lib/jelix-modules/jpref/classes/jPrefManager.php
@@ -8,8 +8,8 @@
 * @licence  http://www.gnu.org/licenses/lgpl.html GNU Lesser General Public Licence, see LICENCE file
 */
 
-require_once(JELIX_LIB_PATH.'pref/jPrefItem.class.php');
-require_once(JELIX_LIB_PATH.'pref/jPrefItemGroup.class.php');
+require_once(__DIR__.'/jPrefItem.php');
+require_once(__DIR__.'/jPrefItemGroup.php');
 
 class jPrefManager{
 


### PR DESCRIPTION
Incorrect path for required files before class declaration, they were pointing to the old location which is now obsolete as jPref is moved into a separate module.
