### PR TITLE
jquery.include.js : compat with jQuery 1.9

### DIFF
--- a/lib/jelix-www/jquery/include/jquery.include.js
+++ b/lib/jelix-www/jquery/include/jquery.include.js
@@ -159,7 +159,7 @@
                                 if (elementTag !== null) {
                                         el[i] = $.createElement(finfo.filename, elementTag);
                                         if (el[i]) {
-                                                if ($.browser.msie) {
+                                                if (/MSIE/i.test(navigator.userAgent)) {
                                                         el[i].onreadystatechange = function(){
                                                                 if (this.readyState === 'loaded' || this.readyState === 'complete') {
                                                                         $.__loadedSuccessfully(taskId);


### PR DESCRIPTION
compat with jQuery 1.9

The jQuery.browser() method has been removed in 1.9 (http://goo.gl/QrwVA)
