### PR TITLE
ticket #1507 - Solve a bug to get module's name with cmdline action (ticket 1507).

### DIFF
--- a/lib/jelix/core/jCmdlineCoordinator.class.php
+++ b/lib/jelix/core/jCmdlineCoordinator.class.php
@@ -33,7 +33,7 @@ class jCmdlineCoordinator extends jCoordinator {
     * This method should be called in a Command line entry point.
     * @param  jRequestCmdline  $request the command line request object
     */
-    public function process($request){
+    public function process($request=null){
         $this->allErrorMessages = jBasicErrorHandler::$initErrorMessages;
         parent::process($request);
         exit($this->response->getExitCode());

--- a/lib/jelix/core/jCoordinator.class.php
+++ b/lib/jelix/core/jCoordinator.class.php
@@ -151,6 +151,7 @@ class jCoordinator {
                 $this->actionName = 'default:index';
             }
         }
+        jApp::pushCurrentModule($this->moduleName);
 
         $this->action = new jSelectorActFast($this->request->type, $this->moduleName, $this->actionName);
 


### PR DESCRIPTION
The ticket #1507 seems to be caused by an empty return of function jApp::getCurrentModule().
Comparing the jCoordinator class in jelix 1.5 and 1.4, I see the jContext::push(...) used in 1.4 in process() before getController() has been deleted and not replaced by jApp::pushCurrentModule(...) as in other classes.
