### PR TITLE
Add oci* support for Oracle.

### DIFF
--- a/lib/jelix/plugins/db/oci/oci.daobuilder.php
+++ b/lib/jelix/plugins/db/oci/oci.daobuilder.php
@@ -4,7 +4,8 @@
 * @subpackage db_driver
 * @author     Laurent Jouanneau
 * @contributor Gwendal Jouannic
-* @copyright  2007-2009 Laurent Jouanneau
+* @contributor Philippe Villiers
+* @copyright  2007-2009 Laurent Jouanneau, 2013 Philippe Villiers
 * @link      http://www.jelix.org
 * @licence  http://www.gnu.org/licenses/lgpl.html GNU Lesser General Public Licence, see LICENCE file
 */
@@ -22,11 +23,14 @@ class ociDaoBuilder extends jDaoGenerator {
     protected function buildOuterJoins(&$tables, $primaryTableName){
         $sqlFrom = '';
         $sqlWhere ='';
-        foreach($this->_dataParser->getOuterJoins() as $tablejoin){
+        foreach($this->_dataParser->getOuterJoins() as $tablejoin) {
             $table= $tables[$tablejoin[0]];
             $tablename = $this->_encloseName($table['name']);
 
-            $r = $this->_encloseName($table['realname']).' '.$tablename;
+            if($table['name']!=$table['realname'])
+                $r =$this->_encloseName($table['realname']).' '.$tablename;
+            else
+                $r =$this->_encloseName($table['realname']);
 
             $fieldjoin='';
 
@@ -61,7 +65,247 @@ class ociDaoBuilder extends jDaoGenerator {
      * Replaces the lastInsertId which doesn't work with oci
      */
     protected function buildUpdateAutoIncrementPK($pkai) {
-        return '          $record->'.$pkai->name.'= $this->_conn->query(\'SELECT '.$pkai->sequenceName.'.currval as '.$pkai->name.' from dual\')->fetch()->'.$pkai->name.';';
+        return '          $record->'.$pkai->name.'= $this->_conn->query(\'SELECT '.$pkai->sequenceName.'.currval as "'.$pkai->name.'" from dual\')->fetch()->'.$pkai->name.';';
     }
 
+    /**
+     * build the insert() method in the final class
+     * @return string the source of the method
+     */
+    protected function buildInsertMethod($pkFields) {
+        $pkai = $this->getAutoIncrementPKField();
+
+        // Explicitly forbid auto-incement
+        if (is_object ($pkai)) {
+            if ($pkai->autoIncrement) {
+                throw new Exception ('Please don\'t use auto-increment and use a sequence instead for the table ' .
+                                            $this->tableRealName);
+            }
+        }
+
+        $src = array();
+        $src[] = 'public function insert ($record){';
+
+        if($this->_dataParser->hasEvent('insertbefore') || $this->_dataParser->hasEvent('insert')){
+            $src[] = '   jEvent::notify("daoInsertBefore", array(\'dao\'=>$this->_daoSelector, \'record\'=>$record));';
+        }
+
+        $src[] = '    $query = \'INSERT INTO '.$this->tableRealNameEsc.' (';
+
+        $fields = $this->_getPropertiesBy('PrimaryTable');
+        list($fields, $values) = $this->_prepareValues($fields,'insertPattern', 'record->');
+        $fieldsObj = $this->_getPropertiesBy('PrimaryTable');
+
+        $binds = array();
+        $returningInto = array();
+        $returningBind = '';
+
+        foreach($fieldsObj as $k => $fieldData) {
+            if(in_array($fieldData->name, $fields)) {
+                // We have a blob/clob: replace the field value by an Oracle marker
+                if($fieldData->datatype == 'clob' || $fieldData->datatype == 'blob') {
+                    $values[$k] = ':' . $fieldData->fieldName;
+                    $binds[$fieldData->fieldName] = $fieldData->name;
+                } else {
+                    if ($fieldData->isPK) {
+                        // Use a returning into only for the numeric primary keys
+                        switch($fieldData->datatype) {
+                            case 'int':
+                            case 'integer':
+                            case 'tinyint':
+                            case 'smallint':
+                            case 'mediumint':
+                            case 'bigint':
+                            case 'number':
+                                $returningInto['field'][] = $fieldData->fieldName;
+                                $returningInto['bind'][] = ':' . $fieldData->name;
+                                $returningBind .= '    $prep->bindParam(\':' . $fieldData->name . '\', $record->' . $fieldData->name . ', SQLT_INT, -1);' . "\n";
+                            break;
+                        }
+                    } else {
+                        switch($fieldData->datatype) {
+                            case 'varchar':
+                            case 'varchar2':
+                            case 'nvarchar2':
+                            case 'character':
+                            case 'character varying':
+                            case 'char':
+                            case 'nchar':
+                            case 'name':
+                            case 'longvarchar':
+                            case 'string':
+                                $values[$k] = ':' . $fieldData->fieldName;
+                                $binds[$fieldData->fieldName] = $fieldData->name;
+                        }
+                    }
+                }
+            }
+        }
+
+        $src[] = implode(',',$fields);
+        $src[] = ') VALUES (';
+        $src[] = implode(', ',$values);
+        $src[] = ")";
+
+        if(!empty($returningInto)) {
+            // We have RETURNING INTO
+            $src[] = '    RETURNING ' . implode (',', $returningInto['field']) . ' INTO ' . implode (',', $returningInto['bind']);
+        }
+
+        $src[] = "';";
+
+        if($pkai !== null)
+            $src[] = '}';
+
+        // We have clob/string binds
+        if(!empty($binds) || !empty($returningInto)) {
+            $src[] = '   $prep = $this->_conn->prepare ($query);';
+            // Bind the clobs/strings
+            if(!empty($binds)) {
+                foreach($binds as $variable => $name) {
+                    $src[] = '   $prep->bindParam(\':'.$variable.'\', $record->'.$name.');';
+                }
+            }
+            // Bind the keys
+            if(!empty($returningInto)) {
+                $src[] = $returningBind;
+            }
+             $src[] = '   $result = $prep->execute();';
+        } else {
+            $src[] = '   $result = $this->_conn->exec ($query);';
+        }
+
+        if($pkai !== null){
+            $src[] = '   if(!$result)';
+            $src[] = '       return false;';
+
+            $src[] = '   if($record->'.$pkai->name.' < 1 ) ';
+            $src[] = $this->buildUpdateAutoIncrementPK($pkai);
+        }
+
+        // we generate a SELECT query to update field on the record object, which are autoincrement or calculated
+        $fields = $this->_getPropertiesBy('FieldToUpdate');
+        if (count($fields)) {
+            $result = array();
+            foreach ($fields as $id=>$prop){
+                $result[]= $this->buildSelectPattern($prop->selectPattern, '', $prop->fieldName, $prop->name);
+            }
+
+            $sql = 'SELECT '.(implode (', ',$result)). ' FROM '.$this->tableRealNameEsc.' WHERE ';
+            $sql.= $this->buildSimpleConditions($pkFields, 'record->', false);
+
+            $src[] = '  $query =\''.$sql.'\';';
+            $src[] = '  $rs  =  $this->_conn->query ($query);';
+            $src[] = '  $newrecord =  $rs->fetch ();';
+            foreach ($fields as $id=>$prop){
+                $src[] = '  $record->'.$prop->name.' = $newrecord->'.$prop->name.';';
+            }
+        }
+
+        if($this->_dataParser->hasEvent('insertafter') || $this->_dataParser->hasEvent('insert')){
+            $src[] = '   jEvent::notify("daoInsertAfter", array(\'dao\'=>$this->_daoSelector, \'record\'=>$record));';
+        }
+
+        $src[] = '    return $result;';
+        $src[] = '}';
+
+        return implode("\n",$src);
+    }
+
+    /**
+     * build the update() method for the final class
+     * @return string the source of the method
+     */
+    protected function buildUpdateMethod($pkFields) {
+        $src = array();
+        
+        $src[] = 'public function update ($record){';
+        list($fields, $values) = $this->_prepareValues($this->_getPropertiesBy('PrimaryFieldsExcludePk'),'updatePattern', 'record->');
+        $fieldsObj = $this->_getPropertiesBy('PrimaryFieldsExcludePk');
+        
+        if(count($fields)){
+
+            if($this->_dataParser->hasEvent('updatebefore') || $this->_dataParser->hasEvent('update')){
+                $src[] = '   jEvent::notify("daoUpdateBefore", array(\'dao\'=>$this->_daoSelector, \'record\'=>$record));';
+            }
+
+            $src[] = '   $query = \'UPDATE '.$this->tableRealNameEsc.' SET ';
+            $sqlSet = '';
+            
+            $binds = array();
+            
+            foreach($fieldsObj as $k=> $fieldData){
+                if($fieldData->updatePattern != '') {
+                    switch($fieldData->datatype) {
+                    // We have blob/clob or string(s): replace the field value by an Oracle marker
+                        case 'clob':
+                        case 'blob':
+                        case 'varchar':
+                        case 'varchar2':
+                        case 'nvarchar2':
+                        case 'character':
+                        case 'character varying':
+                        case 'char':
+                        case 'nchar':
+                        case 'name':
+                        case 'longvarchar':
+                        case 'string':
+                            $values[$k] = ':' . $fieldData->fieldName;
+                            $binds[$fieldData->fieldName] = $fieldData->name;
+                            $sqlSet.= ', '.$fieldData->fieldName. '= :' . $fieldData->fieldName;
+                        break;
+                        default:
+                            $sqlSet.= ', '.$fieldData->fieldName. '= '. $values[$k];
+                    }
+                }
+            }
+            $src[] = substr($sqlSet, 1);
+
+            $sqlCondition = $this->buildSimpleConditions($pkFields, 'record->', false);
+            if($sqlCondition!='') {
+                $src[] = ' where '.$sqlCondition;
+            }
+
+            $src[] = "';";
+
+            // We have clob/strings binds
+            if(!empty($binds)) {
+                $src[] = '   $prep = $this->_conn->prepare ($query);';
+                foreach($binds as $variable => $name) {
+                    $src[] = '   $prep->bindParam(\':'.$variable.'\', $record->'.$name.');';
+                }
+                 $src[] = '   $result = $prep->execute();';
+            } else {
+                $src[] = '   $result = $this->_conn->exec ($query);';
+            }
+
+            // we generate a SELECT query to update field on the record object, which are autoincrement or calculated
+            $fields = $this->_getPropertiesBy('FieldToUpdateOnUpdate');
+            if (count($fields)) {
+                $result = array();
+                foreach ($fields as $id=>$prop){
+                    $result[]= $this->buildSelectPattern($prop->selectPattern, '', $prop->fieldName, $prop->name);
+                }
+
+                $sql = 'SELECT '.(implode (', ',$result)). ' FROM '.$this->tableRealNameEsc.' WHERE ';
+                $sql.= $this->buildSimpleConditions($pkFields, 'record->', false);
+
+                $src[] = '  $query =\''.$sql.'\';';
+                $src[] = '  $rs  =  $this->_conn->query ($query, jDbConnection::FETCH_INTO, $record);';
+                $src[] = '  $record =  $rs->fetch ();';
+            }
+
+            if($this->_dataParser->hasEvent('updateafter') || $this->_dataParser->hasEvent('update'))
+                $src[] = '   jEvent::notify("daoUpdateAfter", array(\'dao\'=>$this->_daoSelector, \'record\'=>$record));';
+
+            $src[] = '   return $result;';
+        } else {
+            //the dao is mapped on a table which contains only primary key : update is impossible
+            // so we will generate an error on update
+            $src[] = "     throw new jException('jelix~dao.error.update.impossible',array('".$this->_daoId."','".$this->_daoPath."'));";
+        }
+
+        $src[] = ' }';//ends the update function
+        return implode("\n",$src);
+    }
 }

--- a/lib/jelix/plugins/db/oci/oci.dbconnection.php
+++ b/lib/jelix/plugins/db/oci/oci.dbconnection.php
@@ -1,0 +1,156 @@
+<?php
+/**
+* @package    jelix
+* @subpackage db_driver
+* @author     Philippe Villiers
+* @copyright  2013 Philippe Villiers
+*
+* @link        http://www.jelix.org
+* @licence  http://www.gnu.org/licenses/lgpl.html GNU Lesser General Public Licence, see LICENCE file
+*/
+require_once(dirname(__FILE__).'/oci.dbresultset.php');
+
+/**
+ *
+ * @package    jelix
+ * @subpackage db_driver
+ */
+class ociDbConnection extends jDbConnection {
+
+    // Charsets equivalents
+    protected $_charsets =array( 'UTF-8'=>'AL32UTF8', 'ISO-8859-1'=>'WE8ISO8859P1');
+
+    function __construct($profile){
+        if(!function_exists('oci_connect')){
+            throw new jException('jelix~db.error.nofunction','oci');
+        }
+        parent::__construct($profile);
+
+        $this->dbms = 'oci';
+    }
+
+    protected function _connect () {
+        $funcConnect = (isset($this->profile['persistent']) && $this->profile['persistent'] ? 'oci_pconnect':'oci_connect');
+
+        if(isset($this->profile['dsn'])) {
+            $connString = $this->profile['dsn'];
+        } else {
+            $connString = $this->profile['host'];
+            if(isset($this->profile['port'])) {
+                $connString .= ':' . $this->profile['port'];
+            }
+            $connString .= '/' . $this->profile['database'];
+        }
+        $charset = $this->_charsets[jApp::config()->charset];
+
+        $conn = $funcConnect($this->profile['user'], $this->profile['password'], $connString, $charset);
+        if (!$conn) {
+            $err = oci_error();
+            throw new jException('jelix~db.error.connection', $this->profile['host']);
+        }
+        
+        return $conn;
+    }
+
+    protected function _disconnect() {
+        return oci_close ($this->_connection);
+    }
+
+    protected function _doQuery ($queryString) {
+        if ($stId = oci_parse($this->_connection, $queryString)){
+            $rs= new ociDbResultSet ($stId, $this->_connection);
+            $rs->_connector = $this;
+            if($res = $rs->execute()) {
+                return $rs;
+            } else {
+                $rs = false;
+                $err = oci_error();
+                throw new jException('jelix~db.error.query.bad', $err['message'].'('.$queryString.')');
+            }
+        } else {
+            $rs = false;
+            $err = oci_error();
+            throw new jException('jelix~db.error.query.bad', $err['message'].'('.$queryString.')');
+        }
+        return $rs;
+    }
+
+    protected function _doLimitQuery($queryString, $offset, $number) {
+        $offset = $offset + 1; // rnum begins at 1
+        $queryString = 'SELECT * FROM ( SELECT ocilimit.*, rownum rnum FROM ('.$queryString.') ocilimit WHERE
+            rownum<'.(intval($offset)+intval($number)).'  ) WHERE rnum >='.intval($offset);
+        return $this->_doQuery ($queryString);
+    }
+
+    protected function _doExec($query) {
+        if($rs = $this->_doQuery($query)) {
+            return oci_num_rows($rs->id());
+        } else {
+            return 0;
+        }
+    }
+
+    public function prepare($query) {
+        $stId = oci_parse($this->_connection, $query);
+        if($stId){
+            $rs = new ociDbResultSet ($stId, $this->_connection);
+        } else {
+            $err = oci_error();
+            throw new jException('jelix~db.error.query.bad', $err['message'].'('.$query.')');
+        }
+        return $rs;
+    }
+
+
+    public function beginTransaction (){
+        return true;
+    }
+
+    public function commit () {
+        return oci_commit($this->_connection);
+    }
+
+    public function rollback () {
+        return oci_rollback($this->_connection);
+    }
+
+    public function errorInfo() {
+        $err = oci_error();
+        return array( 'HY000', $err['code'], $err['message']);
+    }
+
+    public function errorCode() {
+        $err = oci_error();
+        return $err['code'];
+    }
+
+    public function lastInsertId($seqName = '') {
+        if($seqName == '') {
+            trigger_error(get_class($this).'::lastInstertId invalid sequence name', E_USER_WARNING);
+            return false;
+        }
+        $cur = $this->query('select ' . $seqname . '.currval as "id" from dual');
+        if($cur) {
+            $res = $cur->fetch();
+            if($res) {
+                return $res->id;
+            } else {
+                return false;
+            }
+        } else {
+            trigger_error(get_class($this).'::lastInstertId invalid sequence name', E_USER_WARNING);
+            return false;
+        }
+    }
+
+    public function getAttribute($id) {
+    }
+
+    public function setAttribute($id, $value) {
+    }
+
+    protected function _autoCommitNotify ($state) {
+        $this->_doExec('SET AUTOCOMMIT '.($state ? 'ON' : 'OFF'));
+    }
+}
+

--- a/lib/jelix/plugins/db/oci/oci.dbresultset.php
+++ b/lib/jelix/plugins/db/oci/oci.dbresultset.php
@@ -1,0 +1,98 @@
+<?php
+/**
+* @package    jelix
+* @subpackage db_driver
+* @author     Philippe Villiers
+* @copyright  2013 Philippe Villiers
+*
+* @link        http://www.jelix.org
+* @licence  http://www.gnu.org/licenses/lgpl.html GNU Lesser General Public Licence, see LICENCE file
+*/
+
+/**
+ * @package    jelix
+ * @subpackage db_driver
+ */
+class ociDbResultSet extends jDbResultSet {
+    protected $_cnt;
+
+    public function __construct ($stmtId, $cnt=null) {
+        $this->_cnt = $cnt;
+        parent::__construct($stmtId);
+    }
+
+    protected function _free () {
+        return oci_free_statement($this->_idResult);
+    }
+
+    protected function _fetch () {
+    }
+
+    protected function _rewind () {
+    }
+
+    public function fetch() {
+        if ($this->_fetchMode == jDbConnection::FETCH_CLASS || $this->_fetchMode == jDbConnection::FETCH_INTO) {
+            $res = oci_fetch_object ($this->_idResult);
+            if($res) {
+                $values = get_object_vars ($res);
+                $classObj =  new $this->_fetchModeParam();
+                foreach ($values as $k=>$value) {
+                    $attrName = strtolower($k);
+                    $ociClassName = 'OCI-Lob';
+                    // Check if we have a Lob, to read it correctly
+                    if($value instanceof $ociClassName) {
+                        $classObj->$attrName = $value->read($value->size());
+                    } else {
+                        $classObj->$attrName = $value;
+                    }
+                }
+                $res = $classObj;
+            }
+        } else {
+            $res = oci_fetch_object ($this->_idResult);
+        }
+
+        if ($res && count($this->modifier)) {
+            foreach($this->modifier as $m)
+                call_user_func_array($m, array($res, $this));
+        }
+        return $res;
+    }
+
+    /**
+     * Return all results in an array. Each result is an object.
+     * @return array
+     */
+    public function fetchAll(){
+        $result = array();
+        while($res =  $this->fetch()) {
+            $result[] = $res;
+        }
+        return $result;
+    }
+
+    public  function rowCount(){
+        return oci_num_rows($this->_idResult);
+    }
+
+    public function bindColumn($column, &$param , $type=null ) {
+        throw new jException('jelix~db.error.feature.unsupported', array('oci','bindColumn'));
+    }
+
+    public function bindParam($parameter, &$variable, $data_type = SQLT_CHR, $length = -1,  $driver_options=null) {
+        return oci_bind_by_name($this->_idResult, $parameter, $variable, $length, $data_type);
+    }
+
+    public function bindValue($parameter, $value, $data_type) {
+        throw new jException('jelix~db.error.feature.unsupported', array('oci','bindValue'));
+    }
+
+    public function columnCount() {
+        return oci_num_fields($this->_idResult);
+    }
+
+    public function execute($parameters=array()) {
+        return oci_execute($this->_idResult);
+    }
+}


### PR DESCRIPTION
Add oci\* support for Oracle.
There is still room for improvments, especially in user-defined DAO methods.

Can easily be backported to 1.3+ versions of Jelix.
