### PR TITLE
Comments correction

### DIFF
--- a/lib/jelix/plugins/auth/class/class.auth.php
+++ b/lib/jelix/plugins/auth/class/class.auth.php
@@ -64,14 +64,14 @@ interface jIAuthDriverClass {
     /**
     * change the password of a user
     * @param string $login the user login
-    * @param string $password the new encrypted password
+    * @param string $cryptedpassword the new encrypted password
     */
     public function updatePassword($login, $cryptedpassword);
 
     /**
     * get the user corresponding to the given login and encrypted password
     * @param string $login the user login
-    * @param string $password the new encrypted password
+    * @param string $cryptedpassword the new encrypted password
     * @return object user informations
     * @deprecated since 1.2.10
     */


### PR DESCRIPTION
In order to generate with phpdocumentor a good doc,
the params of the functions updatePassword and getByLoginPassword must have the same name in the comments and in the implementation.
Actually, doc will be generate with 3 params instead of 2.
