### PR TITLE
Soap : get non-scalar params from client

### DIFF
--- a/lib/jelix/core/request/jSoapRequest.class.php
+++ b/lib/jelix/core/request/jSoapRequest.class.php
@@ -60,4 +60,34 @@ class jSoapRequest extends jRequest {
         return ('jResponseSoap' == $respclass || 'jResponseRedirect' == $respclass);
     }
 
+    /**
+    * Gets the value of a request parameter. If not defined, gets its default value.
+    * @param string  $name           the name of the request parameter
+    * @param mixed   $defaultValue   the default returned value if the parameter doesn't exists
+    * @param boolean $useDefaultIfEmpty true: says to return the default value if the parameter value is ""
+    * @return mixed the request parameter value
+    */
+    
+    public function getParam($name, $defaultValue=null, $useDefaultIfEmpty=false){
+    	if(isset($this->params[$name])){
+			// we cannot use the empty() function because 0 returns true. And maybe we want 0 as a normal value...
+			if(is_scalar($this->params[$name])){
+				if( $useDefaultIfEmpty && trim($this->params[$name]) == '' ){
+					return $defaultValue;
+				}else{
+					return $this->params[$name];
+				}
+			}else{
+				// array or object
+				if( $useDefaultIfEmpty && empty($this->params[$name]) ){
+					return $defaultValue;
+				}else{
+					return $this->params[$name];
+				}
+			}
+		}else{
+			return $defaultValue;
+		}
+    }
+
 }


### PR DESCRIPTION
Some soap clients may pass arrays or objects to the soap server. The trim() function used by jRequest converts scalars objects into empty value. We test the scalar type before the empty test, and we use the empty() function only with scalar types.
