### PR TITLE
Prevent error on invalid input date format

### DIFF
--- a/lib/jelix/plugins/tpl/common/modifier.datetime.php
+++ b/lib/jelix/plugins/tpl/common/modifier.datetime.php
@@ -3,6 +3,7 @@
 * @package    jelix
 * @subpackage jtpl_plugin
 * @author     Laurent Jouanneau
+* @contributor   Philippe Villiers
 * @copyright   2012 Laurent Jouanneau
 * @link        http://www.jelix.org
 * @licence    GNU Lesser General Public Licence see LICENCE file or http://www.gnu.org/licenses/lgpl.html
@@ -38,6 +39,9 @@ function jtpl_modifier_common_datetime($date, $format_out = 'lang_datetime', $fo
         }
         else {
             $date = new DateTime($date);
+        }
+        if(!$date)
+            return '';
         }
     }
 


### PR DESCRIPTION
If $format_in is invalid, $date->format would throw a fatal PHP error. Thi patch fixes the problem.
