### PR TITLE
Add options parameter to jResponseJson

### DIFF
--- a/lib/jelix/core/response/jResponseJson.class.php
+++ b/lib/jelix/core/response/jResponseJson.class.php
@@ -25,6 +25,11 @@ final class jResponseJson extends jResponse {
      */
     public $data = null;
 
+    /**
+     * options bitmask for json_encode()
+     * @var int
+     */
+    public $options = 0;
 
     public function output(){
         
@@ -34,7 +39,7 @@ final class jResponseJson extends jResponse {
         }
         
         $this->_httpHeaders['Content-Type'] = "application/json";
-        $content = json_encode($this->data);
+        $content = json_encode($this->data, $this->options);
         $this->_httpHeaders['Content-length'] = strlen($content);
         $this->sendHttpHeaders();
         echo $content;


### PR DESCRIPTION
This change adds a way to pass options to json_encode() from the response. The options parameter was added in PHP 5.3.0 (http://www.php.net/manual/en/function.json-encode.php).
