### PR TITLE
Correction jRequest->getDomainName

### DIFF
--- a/lib/jelix/core/jRequest.class.php
+++ b/lib/jelix/core/jRequest.class.php
@@ -322,13 +322,13 @@ abstract class jRequest {
       if (jApp::config()->domainName != '') {
          return jApp::config()->domainName;
       }
-      elseif (isset($_SERVER['SERVER_NAME'])) {
-         return $_SERVER['SERVER_NAME'];
-      }
       elseif (isset($_SERVER['HTTP_HOST'])) {
          if (($pos = strpos($_SERVER['HTTP_HOST'], ':')) !== false)
             return substr($_SERVER['HTTP_HOST'],0, $pos);
          return $_SERVER['HTTP_HOST'];
+      }
+      elseif (isset($_SERVER['SERVER_NAME'])) {
+         return $_SERVER['SERVER_NAME'];
       }
       return '';
    }


### PR DESCRIPTION
Dans la fonction jRequest->getDomainName :
- Inversion des tests sur HTTP_HOST et SERVER_NAME car comme SERVER_NAME est normalement toujours existant, HTTP_HOST n'est jamais utilisé (Exmple : utilisation sur un serveur dernière un NAT, les URL des images, ... sont généré avec des adresses local).
