### PR TITLE
finfo_open may not be defined

### DIFF
--- a/lib/jelix-legacy/utils/jFile.class.php
+++ b/lib/jelix-legacy/utils/jFile.class.php
@@ -165,9 +165,13 @@ class jFile {
      * @since 1.1.6
      */
     public static function getMimeType($file){
-        $finfo = finfo_open(FILEINFO_MIME_TYPE);
-        $type = finfo_file($finfo, $file);
-        finfo_close($finfo);
+        if (function_exists('finfo_open')) {
+            $finfo = finfo_open(FILEINFO_MIME_TYPE);
+            $type = finfo_file($finfo, $file);
+            finfo_close($finfo);
+        } else {
+            $type = 'application/octet-stream';
+        }
         return $type;
     }
 
@@ -280,6 +284,7 @@ class jFile {
         'ifb'=>'text/calendar',
         'sgml'=>'text/sgml',
         'htc'=>'text/x-component',
+        'csv'=>'text/csv',
 
         // images
         'png' => 'image/png',


### PR DESCRIPTION
finfo_open needs (PHP >= 5.3.0, PECL fileinfo >= 0.1.0)
jelix needs (PHP >= 5.3.0)
so finfo_open may not be defined
