### PR TITLE
Add _endt to WidgetBase.php to solve a bug in datetime form widget.

### DIFF
--- a/lib/jelix-legacy/forms/HtmlWidget/WidgetBase.php
+++ b/lib/jelix-legacy/forms/HtmlWidget/WidgetBase.php
@@ -41,10 +41,16 @@ abstract class WidgetBase implements WidgetInterface {
 
     protected $valuesSeparator = ' ';
 
+    protected $_endt = '/>';
+
     public function __construct($args) {
         $this->ctrl = $args[0];
         $this->builder = $args[1];
         $this->parentWidget = $args[2];
+
+        if (\jApp::coord()->response != null && \jApp::coord()->response->getType() == 'html') {
+            $this->_endt = (\jApp::coord()->response->isXhtml() ? '/>' : '>');
+        }
     }
     
     /**


### PR DESCRIPTION
There is a bug in datetime form widget because it want to use non-existing _endt property to close its HTML tags. Add it to the WidgetBase class solve the problem and give us possibility to use it in other form widgets.
