### PR TITLE
benjamin.landais : fix Jelix security bug.

### DIFF
--- a/lib/jelix-modules/jacl2/classes/jAcl2.class.php
+++ b/lib/jelix-modules/jacl2/classes/jAcl2.class.php
@@ -63,6 +63,17 @@ class jAcl2 {
     }
 
     /**
+     * call this method to know if the current user has the right with the given value
+     * @param string $subject the key of the subject to check
+     * @param string $resource the id of a resource
+     * @return boolean true if yes
+     */
+    public static function checkManageGroup($subject, $resource=null){
+        $dr = self::_getDriver();
+        return $dr->getManageGroupRight($subject, $resource);
+    }
+    
+    /**
      * clear right cache
      * @since 1.0b2
      */

--- a/lib/jelix-modules/jacl2/classes/jIAcl2Driver.iface.php
+++ b/lib/jelix-modules/jacl2/classes/jIAcl2Driver.iface.php
@@ -24,6 +24,14 @@ interface jIAcl2Driver {
     public function getRight($subject, $resource=null);
 
     /**
+     * Return the possible values of the manage group right on the given subject (and on the optional resource)
+     * @param string $subject the key of the subject
+     * @param string $resource the id of a resource
+     * @return array list of values corresponding to the right
+     */
+    public function getManageGroupRight($subject, $resource=null);
+    
+    /**
      * Clear some cached data, it a cache exists in the driver..
      */
     public function clearCache();

--- a/lib/jelix-modules/jacl2db/daos/jacl2rights.dao.xml
+++ b/lib/jelix-modules/jacl2db/daos/jacl2rights.dao.xml
@@ -26,6 +26,14 @@
                 <in property="id_aclgrp" expr="$groups" />
             </conditions>
         </method>
+        <method name="getManageGroupRightsByGroups" type="select">
+            <parameter name="groups" />
+            <parameter name="resource" />
+            <conditions >
+                <eq property="id_aclres" expr="$resource"/>
+                <in property="id_aclgrp" expr="$groups" />
+            </conditions>
+        </method>
         <method name="getRightsByGroup" type="select">
             <parameter name="group" />
             <conditions >

--- a/lib/jelix-modules/jacl2db/plugins/acl2/db/db.acl2.php
+++ b/lib/jelix-modules/jacl2db/plugins/acl2/db/db.acl2.php
@@ -94,6 +94,35 @@ class dbAcl2Driver implements jIAcl2Driver {
             return true;
     }
 
+    /**
+     * return the value of the manage groupright on the given subject (and on the optional resource)
+     * @param string $subject the key of the subject
+     * @param string $resource the id of a resource
+     * @return boolean true if the right is ok
+     */
+    public function getManageGroupRight($subject, $resource = '-')
+    {
+        if (empty($resource))
+            $resource = '-';
+
+        if (!jAuth::isConnected()) {
+            return self::getAnonymousRight($subject, $resource);
+        }
+
+        // let's load all rights for the groups on which the current user is attached
+        $groups = jAcl2DbUserGroup::getGroups();
+
+        if (count($groups)) {
+            $dao = jDao::get('jacl2db~jacl2rights', 'jacl2_profile');
+            $right = $dao->getRightWithRes($subject, $groups, $resource);
+
+            if ($right === null) {
+                return false;
+            }
+        }
+        return true;
+    }
+
     protected function getAnonymousRight($subject, $resource='-') {
         if (empty($resource))
             $resource = '-';


### PR DESCRIPTION
The bug was on the right tslacl.can.manage.specific.group.
In our application this right is accessed through the check function of jlAcl2Driver wich then calls getRight($subject, $resource='-') on db.acl2.

The right is then selected in the db through the following function of the dao :

                             <method name="getRightsByGroups" type="select">
                                         <parameter name="groups" />
                                         <conditions >
                                             <eq property="id_aclres" value="-"/>
                                             <in property="id_aclgrp" expr="$groups" />
                                         </conditions>
                                     </method>

and as id_aclres is forcely set to "-" some groups wich have only a tslacl.can.manage.specific.group right with a '-' id_aclres can then manage groups for wich they do not have any right.

 In this commit for a security emergency on our side we simply made a new function in jAcl2.class wich correctly check the right (but in db.Acl2 we didn't correctly manage all rights as it's done in public function getRight($subject, $resource='-') )