### PR TITLE
jMailer: fix for ReplyTo meta in tpl

### DIFF
--- a/lib/jelix/utils/jMailer.class.php
+++ b/lib/jelix/utils/jMailer.class.php
@@ -11,7 +11,7 @@
 * @contributor Kévin Lepeltier, GeekBay, Julien Issler
 * @copyright   2006-2012 Laurent Jouanneau
 * @copyright   2008 Kévin Lepeltier, 2009 Geekbay
-* @copyright   2010 Julien Issler
+* @copyright   2010-2015 Julien Issler
 * @link        http://jelix.org
 * @licence     GNU Lesser General Public Licence see LICENCE file or http://www.gnu.org/licenses/lgpl.html
 */
@@ -48,7 +48,7 @@ class jMailer extends PHPMailer {
      * if mailer is file.
     */
     public $filePath = '';
-    
+
     /**
      * indicates if mails should be copied into files, so the developer can verify that all mails are sent.
      */
@@ -84,7 +84,7 @@ class jMailer extends PHPMailer {
         $this->copyToFiles = $config->mailer['copyToFiles'];
 
         parent::__construct(true);
-        
+
     }
 
     /**
@@ -175,7 +175,7 @@ class jMailer extends PHPMailer {
 
             if (isset($metas['ReplyTo']))
                 foreach( $metas['ReplyTo'] as $val )
-                    $this->getAddrName($val, 'ReplyTo');
+                    $this->getAddrName($val, 'Reply-To');
             $mailtpl->assign('ReplyTo', $this->ReplyTo );
 
             if (isset($metas['From'])) {


### PR DESCRIPTION
In bundled phpMailer, ReplyTo is now Reply-to (see class.phpmailer.php on line 784)