### PR TITLE
Update WYMeditor jQueryPath

### DIFF
--- a/lib/jelix-www/js/jforms/htmleditors/wymeditor_basic.js
+++ b/lib/jelix-www/js/jforms/htmleditors/wymeditor_basic.js
@@ -16,10 +16,10 @@ function jelix_wymeditor_wymbasic(textarea_id, form_id, skin, config) {
         jQuery("#"+textarea_id).wymeditor({
             basePath: config.jelixWWWPath+'wymeditor/',
             iframeBasePath : config.jelixWWWPath+'js/jforms/htmleditors/wymeditor_basiciframe/',
-            jQueryPath: config.jqueryPath,
+            jQueryPath: config.jqueryPath != '' ? config.jqueryPath+'jquery.js' : '',
             lang: config.locale.substr(0,2).toLowerCase(),
             toolsItems: [
-                {'name': 'Bold', 'title': 'Strong', 'css': 'wym_tools_strong'}, 
+                {'name': 'Bold', 'title': 'Strong', 'css': 'wym_tools_strong'},
                 {'name': 'Italic', 'title': 'Emphasis', 'css': 'wym_tools_emphasis'},
                 {'name': 'InsertOrderedList', 'title': 'Ordered_List', 'css': 'wym_tools_ordered_list'},
                 {'name': 'InsertUnorderedList', 'title': 'Unordered_List', 'css': 'wym_tools_unordered_list'},

--- a/lib/jelix-www/js/jforms/htmleditors/wymeditor_default.js
+++ b/lib/jelix-www/js/jforms/htmleditors/wymeditor_default.js
@@ -6,7 +6,7 @@ function jelix_wymeditor_default(textarea_id, form_id, skin, config) {
    jQuery(function() {
         jQuery("#"+textarea_id).wymeditor({
             basePath: config.jelixWWWPath+'wymeditor/',
-            jQueryPath: config.jqueryPath,
+            jQueryPath: config.jqueryPath != '' ? config.jqueryPath+'jquery.js' : '',
             lang: config.locale.substr(0,2).toLowerCase(),
             preInit : function(wym) {
                 jQuery('#'+form_id).bind('jFormsUpdateFields', function(event){


### PR DESCRIPTION
Because of this code `c._options.jQueryPath||WYMeditor.computeJqueryPath()`, it's necessary to pass all the jQuery path or nothing.