### PR TITLE
DB Tools - Add optional schema in getFieldList to avoid getting wrong table fields

### DIFF
--- a/lib/jelix-legacy/db/jDbTools.class.php
+++ b/lib/jelix-legacy/db/jDbTools.class.php
@@ -271,9 +271,10 @@ abstract class jDbTools {
     * Retrieve the list of fields of a table
     * @param string $tableName the name of the table
     * @param string $sequence  the sequence used to auto increment the primary key
+    * @param string $schemaName the name of the schema (for postgresql)
     * @return   array    keys are field names and values are jDbFieldProperties objects
     */
-    abstract public function getFieldList ($tableName, $sequence='');
+    abstract public function getFieldList ($tableName, $sequence='', $schemaName='');
 
     /**
      * regular expression to detect comments and end of query

--- a/lib/jelix-legacy/plugins/db/pgsql/pgsql.dbtools.php
+++ b/lib/jelix-legacy/plugins/db/pgsql/pgsql.dbtools.php
@@ -131,14 +131,24 @@ class pgsqlDbTools extends jDbTools {
     * retrieve the list of fields of a table
     * @param string $tableName the name of the table
     * @param string $sequence  the sequence used to auto increment the primary key
+    * @param string $schemaName the name of the schema (for postgresql)
     * @return   array    keys are field names and values are jDbFieldProperties objects
     */
-    public function getFieldList ($tableName, $sequence='') {
+    public function getFieldList ($tableName, $sequence='', $schemaName='') {
         $tableName = $this->_conn->prefixTable($tableName);
         $results = array ();
-        
+
         // get table informations
-        $sql ='SELECT oid, relhaspkey, relhasindex FROM pg_class WHERE relname = \''.$tableName.'\'';
+        $sql =' SELECT oid, relhaspkey, relhasindex';
+        $sql.=' FROM pg_class';
+        if(!empty($schemaName)){
+            $sql.= ' JOIN pg_catalog.pg_namespace n ON n.oid = pg_class.relnamespace';
+        }
+        $sql.=' WHERE relname = \''.$tableName.'\'';
+        if(!empty($schemaName)){
+            $sql.= ' AND n.nspname = \''.$schemaName.'\'';
+        }
+
         $rs = $this->_conn->query ($sql);
         if (! ($table = $rs->fetch())) {
             throw new Exception('dbtools, pgsql: unknown table');


### PR DESCRIPTION
In PostgreSQL, when the user create tables with same name in different schema, it is needed to be able to pass the schema to getFieldList method to be sure to retrieve the correct table oid
