### PR TITLE
add missing method showMessage() in class jelix_TextUI_Command

### DIFF
--- a/lib/jelix-tests/classes/command.php
+++ b/lib/jelix-tests/classes/command.php
@@ -48,6 +48,11 @@ class jelix_TextUI_Command extends PHPUnit_TextUI_Command {
     }
 
 
+    protected function showMessage($message)
+    {
+        echo $message;
+    }
+
     protected function createRunner()
     {
         if ($this->version36) {


### PR DESCRIPTION
class jelix_TextUI_Command calls a showMessage() method when there are no tests in a module or in the app, but this method didn't exist.