### PR TITLE
Allow limitQuery for sqlSrv and Order clause update

### DIFF
--- a/lib/jelix/dao/jDaoFactoryBase.class.php
+++ b/lib/jelix/dao/jDaoFactoryBase.class.php
@@ -393,7 +393,7 @@ abstract class jDaoFactoryBase  {
         $order = array ();
         foreach ($daocond->order as $name => $way){
             if (isset(static::$_properties[$name])) {
-                $order[] = $this->_conn->encloseName(static::$_properties[$name]['table']).'.'.$this->_conn->encloseName(static::$_properties[$name]['fieldName']).' '.$way;
+                $order[] = $this->_conn->encloseName(static::$_properties[$name]['name']).' '.$way;
             }
         }
 

--- a/lib/jelix/db/jDbPDOConnection.class.php
+++ b/lib/jelix/db/jDbPDOConnection.class.php
@@ -182,10 +182,74 @@ class jDbPDOConnection extends PDO {
                 $queryString = 'SELECT * FROM ( SELECT ocilimit.*, rownum rnum FROM ('.$queryString.') ocilimit WHERE
                     rownum<'.(intval($limitOffset)+intval($limitCount)).'  ) WHERE rnum >='.intval($limitOffset);
             }
+            elseif ($this->dbms == 'sqlsrv') {
+				$queryString = $this->limitQuerySqlsrv($queryString, $limitOffset, $limitCount);
         }
         return $this->query ($queryString);
     }
 
+    /**
+    * Create a limitQuery for the SQL server dbms
+    * @param   string   $queryString   the SQL query
+    * @param   integer  $limitOffset   the offset of the first row to return
+    * @param   integer  $limitCount    the maximum of number of rows to return
+    * @return  string  SQL Select.
+    */
+    protected function limitQuerySqlsrv ($queryString, $limitOffset = null, $limitCount = null) {
+        // we suppress existing 'TOP XX'
+        $queryString = preg_replace('/^SELECT TOP[ ]\d*\s*/i', 'SELECT ', trim($queryString));
+
+        $distinct = false;
+
+        // we retrieve the select part and the from part
+        list($select, $from) = preg_split('/\sFROM\s/mi', $queryString, 2);
+
+        $fields = preg_split('/\s*,\s*/', $select);
+        $firstField = preg_replace('/^\s*SELECT\s+/', '', array_shift($fields));
+
+        // is there a distinct?
+        if (stripos($firstField, 'DISTINCT') !== false) {
+            $firstField = preg_replace('/DISTINCT/i', '', $firstField);
+            $distinct = true;
+        }
+
+        // is there an order by? if not, we order with the first field
+        $orderby = stristr($from, 'ORDER BY');
+        if ($orderby === false) {
+            if (stripos($firstField, ' as ') !== false) {
+            list($field, $key) = preg_split('/ as /', $firstField);
+            }
+            else {
+            $key = $firstField;
+            }
+
+            $orderby = ' ORDER BY '.strstr(strstr($key, '.'),'[').' ASC';
+            $from .= $orderby;
+        }
+
+        // first we select all records from the begining to the last record of the selection
+        if(!$distinct)
+            $queryString = 'SELECT TOP ';
+        else
+            $queryString = 'SELECT DISTINCT TOP ';
+
+        $queryString .= ($limitCount+$limitOffset) . ' '.$firstField.','.implode(',', $fields).' FROM '.$from;
+
+        // we must remove the "tableName." from the ORDER BY clause (otherwise it will cause an error "out of bound"
+        $orderby = ' ORDER BY '.preg_replace('/^[^.]*.\s*/', '', $orderby);
+
+        // then we select the last $number records, by retrieving the first $number record in the reverse order
+        $queryString = 'SELECT TOP ' . $limitCount . ' * FROM (' . $queryString . ') AS inner_tbl ';
+        $order_inner = preg_replace(array('/\bASC\b/i', '/\bDESC\b/i'), array('_DESC', '_ASC'), $orderby);
+        $order_inner = str_replace(array('_DESC', '_ASC'), array('DESC', 'ASC'), $order_inner);
+        $queryString .= $order_inner;
+
+        // finally, we retrieve the result in the expected order
+        $queryString = 'SELECT TOP ' . $limitCount . ' * FROM (' . $queryString . ') AS outer_tbl '.$orderby;
+
+        return $queryString;
+    }
+        
     /**
      * sets the autocommit state
      * @param boolean $state the status of autocommit

--- a/lib/jelix/db/jDbPDOConnection.class.php
+++ b/lib/jelix/db/jDbPDOConnection.class.php
@@ -183,7 +183,8 @@ class jDbPDOConnection extends PDO {
                     rownum<'.(intval($limitOffset)+intval($limitCount)).'  ) WHERE rnum >='.intval($limitOffset);
             }
             elseif ($this->dbms == 'sqlsrv') {
-				$queryString = $this->limitQuerySqlsrv($queryString, $limitOffset, $limitCount);
+		$queryString = $this->limitQuerySqlsrv($queryString, $limitOffset, $limitCount);
+	    }
         }
         return $this->query ($queryString);
     }

--- a/lib/jelix/db/jDbPDOConnection.class.php
+++ b/lib/jelix/db/jDbPDOConnection.class.php
@@ -235,9 +235,6 @@ class jDbPDOConnection extends PDO {
 
         $queryString .= ($limitCount+$limitOffset) . ' '.$firstField.','.implode(',', $fields).' FROM '.$from;
 
-        // we must remove the "tableName." from the ORDER BY clause (otherwise it will cause an error "out of bound"
-        $orderby = ' ORDER BY '.preg_replace('/^[^.]*.\s*/', '', $orderby);
-
         // then we select the last $number records, by retrieving the first $number record in the reverse order
         $queryString = 'SELECT TOP ' . $limitCount . ' * FROM (' . $queryString . ') AS inner_tbl ';
         $order_inner = preg_replace(array('/\bASC\b/i', '/\bDESC\b/i'), array('_DESC', '_ASC'), $orderby);


### PR DESCRIPTION
In 1.6.14, doing a query with an ORDER clause return you something like this :
`SELECT [table].[nameField] AS [name] FROM [table] AS [table] ORDER BY table.nameField`. 

But as you can see, the field name has an alias set in the DAO. So it's this alias that should be used for the ORDER clause too. With my edits, the final query looks like this :
`SELECT [table].[nameField] AS [name] FROM [table] AS [table] ORDER BY name`.

This change is necessary for the limitQuery to work, as it use multiple select with the ORDER clause.
Before the changes with ORDER clause : 
```
SELECT TOP 10 * FROM
   (SELECT TOP 10 * FROM 
      (SELECT TOP 10 [table].[nameField] AS [name],
         FROM [table] AS [table]
         ORDER BY table.nameField ASC)
   AS inner_tbl  ORDER BY table.nameField DESC)
AS outer_tbl  ORDER BY table.nameField ASC
```
After changes : 
```
SELECT TOP 10 * FROM
    (SELECT TOP 10 * FROM 
        (SELECT TOP 10 [table].[nameField] AS [name],
            FROM [table] AS [table]
            ORDER BY name ASC) 
    AS inner_tbl  ORDER BY name DESC)
AS outer_tbl  ORDER BY name ASC
```

Unfortunately, I can't test it with other dbms than sqlsrv, but IMO it should work as well.