### PR TITLE
jClassicRequest: data in request's body may be null fix

### DIFF
--- a/lib/jelix/core/request/jClassicRequest.class.php
+++ b/lib/jelix/core/request/jClassicRequest.class.php
@@ -45,7 +45,7 @@ class jClassicRequest extends jRequest {
         $data = $this->readHttpBody();
         if (is_string($data)) {
             $this->params['__httpbody'] = $data;
-        } else {
+        } elseif (is_array($data)) {
             $this->params = array_merge($this->params, $data);
         }
     }


### PR DESCRIPTION
for DELETE requests for example, body may be null, and array_merge excepts arrays as parameters