### PR TITLE
Correction d'un bug si une clause ORDER existe

### DIFF
--- a/lib/jelix/db/jDbPDOConnection.class.php
+++ b/lib/jelix/db/jDbPDOConnection.class.php
@@ -226,7 +226,11 @@ class jDbPDOConnection extends PDO {
 
             $orderby = ' ORDER BY '.strstr(strstr($key, '.'),'[').' ASC';
             $from .= $orderby;
-        }
+        } else {
+	    if(strpos($orderby, '.', 8)){
+		$orderby = ' ORDER BY ' . substr($orderby, strpos($orderby, '.') + 1);
+	    }
+	}
 
         // first we select all records from the begining to the last record of the selection
         if(!$distinct)


### PR DESCRIPTION
Dans un fichier de DAO, une méthode déclaré en XML de type "selectfirst" contenant une clause `<order>` génère une requête SQL erronée pour une base de données SQLSRV.

`[42000]	SQLSTATE[42000]: [Microsoft][ODBC Driver 11 for SQL Server][SQL Server]The multi-part identifier "table2.date" could not be bound.`

Exemple de requête SQL générée à l'heure actuelle : 
<pre><code>
SELECT TOP 1 * FROM (
	SELECT TOP 1 * FROM (
		SELECT TOP 1
			[table1].[numero] as [num1],
			[table2].[numero] as [num2],
			[table3].[numero] as [num3] 
		FROM [table1] AS [table1] 
		LEFT JOIN [table2] AS [table2] ON ( [table1].[num_table2]=[table2].[numero]) 
		LEFT JOIN [table3] AS [table3] ON ( [table1].[num_table3]=[table3].[numero]) 
		ORDER BY [table2].[date] asc) 
	AS inner_tbl  ORDER BY <b>[table2].[date]</b> DESC) 
AS outer_tbl  ORDER BY <b>[table2].[date]</b> asc
</code></pre>

Exemple de requête SQL générée après modification : 
<pre><code>
SELECT TOP 1 * FROM (
	SELECT TOP 1 * FROM (
		SELECT TOP 1
			[table1].[numero] as [num1],
			[table2].[numero] as [num2],
			[table3].[numero] as [num3] 
		FROM [table1] AS [table1] 
		LEFT JOIN [table2] AS [table2] ON ( [table1].[num_table2]=[table2].[numero]) 
		LEFT JOIN [table3] AS [table3] ON ( [table1].[num_table3]=[table3].[numero]) 
		ORDER BY [table2].[date] asc) 
	AS inner_tbl  ORDER BY <b>[date]</b> DESC) 
AS outer_tbl  ORDER BY<b>[date]</b>asc
</code></pre>

Comme on peut le voir, les clauses ORDER BY des _inner_tbl_ et _outer_tbl_ sont générées avec des "**[table2].**". Celle-ci n'existant pas dans leur contexte, cela génère une erreur. La correction mise en place enlève l'identifiant de la table de la clause ORDER BY pour les deux requêtes _inner_tbl_ et _outer_tbl_.