### PR TITLE
Fix: js files for localizing datepicker were inverted

### DIFF
--- a/lib/jelix/core/defaultconfig.ini.php
+++ b/lib/jelix/core/defaultconfig.ini.php
@@ -473,16 +473,16 @@ jqueryui.css[] = $jqueryPath/themes/base/jquery.ui.all.css
 default = $jelix/js/jforms/datepickers/default/init.js
 default.js[]=$jqueryPath/ui/jquery-ui-core-widg-mous-posi.custom.min.js
 default.js[]=$jqueryPath/ui/jquery.ui.datepicker.min.js
-default.js[]=$jelix/js/jforms/datepickers/default/ui.$lang.js
 default.js[]=$jqueryPath/ui/i18n/jquery.ui.datepicker-$lang.js
+default.js[]=$jelix/js/jforms/datepickers/default/ui.$lang.js
 default.css[]=$jqueryPath/themes/base/jquery.ui.all.css
 
 [datetimepickers]
 default = $jelix/js/jforms/datepickers/default/init.js
 default.js[]=$jqueryPath/ui/jquery-ui-core-widg-mous-posi.custom.min.js
 default.js[]=$jqueryPath/ui/jquery.ui.datepicker.min.js
-default.js[]=$jelix/js/jforms/datepickers/default/ui.$lang.js
 default.js[]=$jqueryPath/ui/i18n/jquery.ui.datepicker-$lang.js
+default.js[]=$jelix/js/jforms/datepickers/default/ui.$lang.js
 default.css[]=$jqueryPath/themes/base/jquery.ui.all.css
 
 [htmleditors]


### PR DESCRIPTION
There is a bug in latest 1.6 version: js files for localizing datepicker are inverted. This PR fixes it.