### PR TITLE
Remove warning from jCmdUtils in PHP 7.4

### DIFF
--- a/build/lib/jCmdUtils.class.php
+++ b/build/lib/jCmdUtils.class.php
@@ -44,11 +44,11 @@ class jCmdUtils {
             array_shift($argv); // shift the script name
 
         //---------- get the switches
-        while (count($argv) && $argv[0]{0} == '-') {
+        while (count($argv) && $argv[0][0] == '-') {
             if (isset($sws[$argv[0]])) {
                 if ($sws[$argv[0]]) {
                     $multiple=($sws[$argv[0]] > 1);
-                    if (isset($argv[1]) && $argv[1]{0} != '-') {
+                    if (isset($argv[1]) && $argv[1][0] != '-') {
                         $sw = array_shift($argv);
                         if($multiple)
                             $switches[$sw][] = array_shift($argv);

--- a/lib/jelix/utils/jCmdUtils.class.php
+++ b/lib/jelix/utils/jCmdUtils.class.php
@@ -52,7 +52,7 @@ class jCmdUtils {
         $parameters = array();
 
         //---------- get the switches
-        while (count($argv) && $argv[0]{0} == '-') {
+        while (count($argv) && $argv[0][0] == '-') {
             if (isset($sws[$argv[0]])) {
                 if ($sws[$argv[0]]) {
                     if (isset($argv[1]) && ($argv[1][0] != '-' || !isset($sws[$argv[1]]))) {


### PR DESCRIPTION
There are 2 deprecation warnings in latest 1.6.29 when using jCmdUtils:

> Deprecated: Array and string offset access syntax with curly braces is deprecated in /.../lib/jelix/utils/jCmdUtils.class.php on line 58
> PHP Deprecated:  Array and string offset access syntax with curly braces is deprecated in /.../lib/jelix/utils/jCmdUtils.class.php on line 55

 This PR fixes it.