### PR TITLE
adding possibility to hide some rights to the admins

### DIFF
--- a/lib/jelix-admin-modules/jacl2db_admin/controllers/groups.classic.php
+++ b/lib/jelix-admin-modules/jacl2db_admin/controllers/groups.classic.php
@@ -86,7 +86,6 @@ class groupsCtrl extends jController
         $rights = $this->param('rights', array());
 
         try {
-            jLog::dump($rights, '', 'error');
             $manager = new jAcl2DbAdminUIManager();
             $manager->saveGroupRights($rights, jAuth::getUserSession()->login);
             jMessage::add(jLocale::get('acl2.message.group.rights.ok'), 'ok');
@@ -287,6 +286,10 @@ class groupsCtrl extends jController
             }
         }));
         $subjects = jDao::get('jacl2db~jacl2subject')->findAllSubject()->fetchAll();
+        $hiddenRights = $manager->getHiddenRights();
+        $subjects = array_filter($subjects, function ($elem) use ($hiddenRights) {
+            return !in_array($elem, $hiddenRights);
+        });
         $groupRights = array_filter(array_map(function ($elem) use ($groupRights) {
             if (in_array($elem->id_aclsbj, $groupRights)) {
                 return jLocale::get($elem->label_key);

--- a/lib/jelix-modules/jacl2db/daos/jacl2rights.dao.xml
+++ b/lib/jelix-modules/jacl2db/daos/jacl2rights.dao.xml
@@ -95,6 +95,12 @@
                 <eq property="id_aclgrp" value="__anonymous" />
             </conditions>
         </method>
+        <method name="getHiddenRightsByGroup" type="select">
+            <parameter name="subjects"/>
+            <conditions>
+                 <in property="id_aclsbj" expr="$subjects"/>
+            </conditions>
+        </method>
         <method name="deleteByGroup" type="delete">
            <parameter name="group" />
            <conditions >

--- a/lib/jelix/core/defaultconfig.ini.php
+++ b/lib/jelix/core/defaultconfig.ini.php
@@ -357,6 +357,10 @@ driver=
 driver=
 authAdapterClass="jAcl2JAuthAdapter"
 
+[jacl2]
+hiddenRights=
+hideRights = off
+
 [sessions]
 ; to disable sessions, set the following parameter to 0
 start=1


### PR DESCRIPTION
Some rights have now the possibility to be hidden.
To do so, define a jacl2 section in localconfig.ini.php with a property `hiddenRights` containing the id of the rights to hide and a property `hideRights` set to `on` or `off` to hide the rights or not.
Example: 
```
[jacl2]
hiddenRights[] = auth.users.view
hiddenRights[] = auth.users.password.change
hideRights = on
```
The value of the hiddenRights won't be changed once they are hidden.