### PR TITLE
Fix logout with persistant cookie

### DIFF
--- a/lib/jelix/auth/jAuth.class.php
+++ b/lib/jelix/auth/jAuth.class.php
@@ -539,7 +539,7 @@ class jAuth
 
         if (isset($config['persistant_enable']) && $config['persistant_enable']) {
             if (isset($config['persistant_cookie_name'])) {
-                setcookie($config['persistant_cookie_name'].'[auth]', '', time() - 3600, $config['persistant_cookie_path'], '', false, true);
+                setcookie($config['persistant_cookie_name'], '', time() - 3600, $config['persistant_cookie_path'], '', false, true);
             } else {
                 jLog::log(jLocale::get('jelix~auth.error.persistant.incorrectconfig', 'persistant_cookie_name'), 'error');
             }


### PR DESCRIPTION
Currently the persistant cookie name sent to the browser is inconsistent between login and logout.
That prevents people from logging out when they have a persistant cookie!!
This PR fixes it.