### PR TITLE
New option for pgsql to set session role

### DIFF
--- a/lib/jelix/plugins/db/pgsql/pgsql.dbconnection.php
+++ b/lib/jelix/plugins/db/pgsql/pgsql.dbconnection.php
@@ -187,6 +187,13 @@ class pgsqlDbConnection extends jDbConnection
             }
         }
 
+        if (isset($this->profile['session_role']) && trim($this->profile['session_role']) != '') {
+            $sql = 'SET ROLE TO '.$this->profile['session_role'];
+            if (!@pg_query($cnx, $sql)) {
+                throw new jException('jelix~db.error.query.bad', pg_last_error($cnx).'('.$sql.')');
+            }
+        }
+
         return $cnx;
     }
 


### PR DESCRIPTION
A new option `session_role` for pgsql connection profile to define the session role.