### PR TITLE
explicit template format in mailTest command

### DIFF
--- a/lib/jelix/core-modules/jelix/Command/MailerTest.php
+++ b/lib/jelix/core-modules/jelix/Command/MailerTest.php
@@ -70,7 +70,7 @@ class MailerTest extends \Jelix\Scripts\ModuleCommandAbstract
 
         $tpl = new \jTpl();
         $tpl->assign('domain_name', $domain);
-        $body = $tpl->fetch('jelix~email_test');
+        $body = $tpl->fetch('jelix~email_test','html');
         $mail->msgHTML($body, '', array($mail, 'html2textKeepLinkSafe'));
         if (!$mail->Send()) {
             $output->writeln('It seems something goes wrong during the message sending.');


### PR DESCRIPTION
while testing mail command in lwc 
`php lizmap/console.php mailer:test mymail@tld.fr `

Got a php Warning
`PHP Warning:  Attempt to read property "defaultResponseType" on null in /srv/lzm/lizmap/vendor/jelix/jelix/lib/jelix/core/selector/jSelectorTpl.class.php `
From https://github.com/jelix/jelix/blob/ef1702521cff3faa19d9da088e7af9db1c533891/lib/jelix/core-modules/jelix/Command/MailerTest.php#L73

Because in a Command "context" the request is unset ? 
https://github.com/jelix/jelix/blob/ef1702521cff3faa19d9da088e7af9db1c533891/lib/jelix/core/selector/jSelectorTpl.class.php#L47

The PR explicitly declare the template as html, but i wonder if a better solution can be done 