### PR TITLE
fix Acl2 cmd list table display

### DIFF
--- a/lib/jelix-modules/jacl2db/Command/Acl2/RightsList.php
+++ b/lib/jelix-modules/jacl2db/Command/Acl2/RightsList.php
@@ -43,6 +43,7 @@ class RightsList extends \Jelix\Scripts\ModuleCommandAbstract
 
         foreach ($rs as $rec) {
             $table->addRow(array(
+                '',
                 'Anonymous',
                 $rec->id_aclsbj.($rec->canceled == '1' ? ' (forbidden)' : ''),
                 $rec->id_aclres,


### PR DESCRIPTION
Add an empty cell for anonymous group in ` acl2:list` command

From 

![acl_anonymous_bad](https://user-images.githubusercontent.com/43475951/217308047-72ee5a20-3823-4f94-9ecb-887d507b5050.png)

to
![acl_anonymous_ok](https://user-images.githubusercontent.com/43475951/217308059-68a7cc04-9008-4169-93ea-a4ec310f5af4.png)
