### PR TITLE
jResponseBinary accepts callable content: strlen is not usable

### DIFF
--- a/lib/jelix/core/response/jResponseBinary.class.php
+++ b/lib/jelix/core/response/jResponseBinary.class.php
@@ -125,7 +125,9 @@ class jResponseBinary extends jResponse
                 throw new jException('jelix~errors.repbin.unknown.file', $this->fileName);
             }
         } else {
-            $this->_httpHeaders['Content-Length'] = strlen($this->content);
+            if (is_string($this->content)) {
+                $this->_httpHeaders['Content-Length'] = strlen($this->content);
+            }
             $this->sendHttpHeaders();
             session_write_close();
             if (is_callable($this->content)) {


### PR DESCRIPTION
Fixes: `strlen(): Argument #1 ($str) must be of type string, Closure given lib/jelix/core/response/jResponseBinary.class.php	128`