### PR TITLE
[Feature] Add support for generated columns

### DIFF
--- a/lib/jelix/db/jDbColumn.class.php
+++ b/lib/jelix/db/jDbColumn.class.php
@@ -209,6 +209,13 @@ class jDbColumn
     public $hasDefault = false;
 
     /**
+     * says if the column is generated.
+     *
+     * @var bool
+     */
+    public $generated = false;
+
+    /**
      * The length for a string.
      *
      * @var int
@@ -256,12 +263,14 @@ class jDbColumn
         $length = 0,
         $hasDefault = false,
         $default = null,
-        $notNull = false
+        $notNull = false,
+        $generated = false
     ) {
         $this->type = $type;
         $this->name = $name;
         $this->length = $length;
         $this->hasDefault = $hasDefault;
+        $this->generated = $generated;
         if ($hasDefault) {
             $this->default = ($notNull && $default === null ? '' : $default);
         } else {

--- a/lib/jelix/db/jDbTools.class.php
+++ b/lib/jelix/db/jDbTools.class.php
@@ -85,6 +85,13 @@
       */
      public $hasDefault = false;
 
+     /**
+      * says if the column is generated.
+      *
+      * @var bool
+      */
+     public $generated = false;
+
      public $length = 0;
 
      /**

--- a/lib/jelix/db/tools/jDbPgsqlTools.php
+++ b/lib/jelix/db/tools/jDbPgsqlTools.php
@@ -260,7 +260,7 @@ class jDbPgsqlTools extends jDbTools
         // pg_get_expr on adbin, not compatible with pgsql < 9
         $adColName = ($version < 12 ? 'd.adsrc' : 'pg_get_expr(d.adbin,d.adrelid) AS adsrc');
 
-        $sql_get_fields = "SELECT t.typname, a.attname, a.attnotnull, a.attnum, a.attlen, a.atttypmod,
+        $sql_get_fields = "SELECT t.typname, a.attname, a.attnotnull, a.attnum, a.attlen, a.atttypmod, a.attgenerated,
         a.atthasdef, {$adColName}
         FROM pg_type t, pg_attribute a LEFT JOIN pg_attrdef d ON (d.adrelid=a.attrelid AND d.adnum=a.attnum)
         WHERE
@@ -276,6 +276,7 @@ class jDbPgsqlTools extends jDbTools
             $field->notNull = ($line->attnotnull == 't');
             $field->hasDefault = ($line->atthasdef == 't');
             $field->default = $line->adsrc;
+            $field->generated = ($line->attgenerated != '');
 
             $typeinfo = $this->getTypeInfo($field->type);
             $field->unifiedType = $typeinfo[1];

--- a/lib/jelix/plugins/db/pgsql/pgsql.dbschema.php
+++ b/lib/jelix/plugins/db/pgsql/pgsql.dbschema.php
@@ -39,7 +39,7 @@ class pgsqlDbTable extends jDbTable
         // pg_get_expr on adbin, not compatible with pgsql < 9
         $adColName = ($version < 12 ? 'd.adsrc' : 'pg_get_expr(d.adbin,d.adrelid) AS adsrc');
 
-        $sql = "SELECT a.attname, a.attnotnull, a.atthasdef, a.attlen, a.atttypmod,
+        $sql = "SELECT a.attname, a.attnotnull, a.atthasdef, a.attlen, a.atttypmod, a.attgenerated,
                 FORMAT_TYPE(a.atttypid, a.atttypmod) AS type, a.attndims,
                 {$adColName}, co.contype AS primary, co.conname
             FROM pg_attribute AS a
@@ -58,11 +58,12 @@ class pgsqlDbTable extends jDbTable
             $notNull = ($line->attnotnull == 't');
             $default = $line->adsrc;
             $hasDefault = ($line->atthasdef == 't');
+            $generated = ($line->attgenerated != '');
             if ($type == 'boolean' && $hasDefault) {
                 $default = (strtolower($default) === 'true');
             }
 
-            $col = new jDbColumn($name, $type, $length, $hasDefault, $default, $notNull);
+            $col = new jDbColumn($name, $type, $length, $hasDefault, $default, $notNull, $generated);
 
             $typeinfo = $tools->getTypeInfo($type);
             if (is_string($default) && preg_match('/^nextval\(([^\)]*)\)$/', $default, $m)) {

--- a/testapp/docker-compose.yml
+++ b/testapp/docker-compose.yml
@@ -2,7 +2,7 @@ name: jelix-${JLX_BRANCH}-tests
 
 services:
   pgsql:
-    image: postgres:11
+    image: postgres:13
     container_name: "jelix_${JLX_BRANCH}_test_pgsql"
     environment:
       POSTGRES_DB: testapp

--- a/testapp/docker-conf/phpfpm/appctl.sh
+++ b/testapp/docker-conf/phpfpm/appctl.sh
@@ -103,7 +103,7 @@ function resetMysql() {
 
 function resetPostgresql() {
   echo "--- Reset Postgresql database"
-  PGTABLES="jacl2_group jacl2_rights jacl2_subject jacl2_subject_group jacl2_user_group jsessions labels1_tests labels_tests product_tags_test product_test products testkvdb"
+  PGTABLES="jacl2_group jacl2_rights jacl2_subject jacl2_subject_group jacl2_user_group jsessions labels1_tests labels_tests product_tags_test product_test products testkvdb generated_column_test"
   for TABLE in $PGTABLES
   do
       PGPASSWORD=jelix psql -h pgsql -U test_user -d testapp -c "drop table if exists $TABLE cascade;"

--- a/testapp/modules/jelix_tests/install/install.pgsql.sql
+++ b/testapp/modules/jelix_tests/install/install.pgsql.sql
@@ -49,7 +49,17 @@ CREATE TABLE products (
     promo boolean NOT NULL
 );
 
+CREATE TABLE generated_column_test (
+    id serial NOT NULL,
+    description character varying(150) NOT NULL,
+    amount integer,
+    change numeric,
+    total numeric GENERATED ALWAYS AS (amount * change) STORED
+);
+
 SELECT pg_catalog.setval(pg_catalog.pg_get_serial_sequence('products', 'id'), 1, false);
+
+SELECT pg_catalog.setval(pg_catalog.pg_get_serial_sequence('generated_column_test', 'id'), 1, false);
 
 ALTER TABLE ONLY product_tags_test
     ADD CONSTRAINT product_tags_test_pkey PRIMARY KEY (product_id, tag);
@@ -71,4 +81,5 @@ ALTER TABLE ONLY product_test
 ALTER TABLE ONLY products
     ADD CONSTRAINT products_pkey PRIMARY KEY (id);
 
-
+ALTER TABLE ONLY generated_column_test
+    ADD CONSTRAINT generated_column_test_pkey PRIMARY KEY (id);


### PR DESCRIPTION
Ticket reference #405

NOTES:
- support is, for now, only for **PostgreSQL**
- following pgsql [doc](https://www.postgresql.org/docs/13/catalog-pg-attribute.html),  `attgenerated` return zero byte ('') if column is not generated, otherwise 's'. Since more value could be added in the future, I would consider as "generated columns" all columns that have `attgenerated != ''`. In fact, `attgenerated = 's' ` could be too restrictive and I would include all generated column, no matter their type.
- with "support" I mean that jelix can detect if a pgsql column is generated or not, but there is no dedicated method, for now, to CREATE generated columns. I'll let this feature for a separated PR.