### PR TITLE
Add HTML Placeholder for input/texteara controls

### DIFF
--- a/lib/jelix/forms/controls/jFormsControlHtmlEditor.class.php
+++ b/lib/jelix/forms/controls/jFormsControlHtmlEditor.class.php
@@ -23,6 +23,7 @@ class jFormsControlHtmlEditor extends jFormsControl
     public $cols = 40;
     public $config = 'default';
     public $skin = 'default';
+    public $placeholder = '';
 
     public function __construct($ref)
     {

--- a/lib/jelix/forms/controls/jFormsControlInput.class.php
+++ b/lib/jelix/forms/controls/jFormsControlInput.class.php
@@ -21,6 +21,7 @@ class jFormsControlInput extends jFormsControl
 {
     public $type = 'input';
     public $size = 0;
+    public $placeholder = '';
 
     public function setDataFromDao($value, $daoDatatype)
     {

--- a/lib/jelix/forms/controls/jFormsControlTextarea.class.php
+++ b/lib/jelix/forms/controls/jFormsControlTextarea.class.php
@@ -22,6 +22,7 @@ class jFormsControlTextarea extends jFormsControl
     public $type = 'textarea';
     public $rows = 5;
     public $cols = 40;
+    public $placeholder = '';
 
     /**
      * @since 1.2

--- a/lib/jelix/forms/controls/jFormsControlWikiEditor.class.php
+++ b/lib/jelix/forms/controls/jFormsControlWikiEditor.class.php
@@ -24,6 +24,7 @@ class jFormsControlWikiEditor extends jFormsControl
     public $rows = 5;
     public $cols = 40;
     public $config = 'default';
+    public $placeholder = '';
 
     public function __construct($ref)
     {

--- a/lib/jelix/forms/jFormsCompiler_jf_1_0.class.php
+++ b/lib/jelix/forms/jFormsCompiler_jf_1_0.class.php
@@ -173,6 +173,7 @@ class jFormsCompiler_jf_1_0
         $this->readEmptyValueLabel($source, $control);
         $this->readHelpHintAlert($source, $control);
         $this->attrSize($source, $attributes);
+        $this->readPlaceholder($source, $control);
         $this->attrReadOnly($source, $attributes);
 
         return false;
@@ -194,6 +195,7 @@ class jFormsCompiler_jf_1_0
         }
         $this->readLabel($source, $control, 'textarea');
         $this->readEmptyValueLabel($source, $control);
+        $this->readPlaceholder($source, $control);
         $this->readHelpHintAlert($source, $control);
         if (isset($attributes['rows'])) {
             $rows = intval($attributes['rows']);
@@ -649,6 +651,19 @@ class jFormsCompiler_jf_1_0
             }
         } else {
             $source[] = '$ctrl->datasource= new jFormsStaticDatasource();';
+        }
+    }
+
+    protected function readPlaceholder(&$source, $control)
+    {
+        if (isset($control->placeholder)) {
+            if (isset($control->placeholder['locale'])) {
+                $placeHolderlocale = (string) $control->placeholder['locale'];
+                $source[] = '$ctrl->placeholder=jLocale::get(\''.$placeHolderlocale.'\');';
+            } else {
+                $label = (string) $control->placeholder;
+                $source[] = '$ctrl->placeholder=\''.str_replace("'", "\\'", $label).'\';';
+            }
         }
     }
 }

--- a/lib/jelix/forms/jFormsCompiler_jf_1_1.class.php
+++ b/lib/jelix/forms/jFormsCompiler_jf_1_1.class.php
@@ -214,6 +214,7 @@ class jFormsCompiler_jf_1_1 extends jFormsCompiler_jf_1_0
         $this->attrRequired($source, $attributes);
         $this->attrDefaultvalue($source, $attributes);
         $this->attrReadOnly($source, $attributes);
+        $this->readPlaceholder($source, $control);
 
         if (isset($attributes['minlength'])) {
             $source[] = '$ctrl->datatype->addFacet(\'minLength\','.intval($attributes['minlength']).');';

--- a/lib/jelix/plugins/formwidget/htmleditor_html/htmleditor_html.formwidget.php
+++ b/lib/jelix/plugins/formwidget/htmleditor_html/htmleditor_html.formwidget.php
@@ -65,6 +65,9 @@ class htmleditor_htmlFormWidget extends \jelix\forms\HtmlWidget\WidgetBase
         if (!isset($attr['cols'])) {
             $attr['cols'] = $this->ctrl->cols;
         }
+        if ($this->ctrl->placeholder != '') {
+            $attr['placeholder'] = $this->ctrl->placeholder;
+        }
 
         echo '<textarea';
         $this->_outputAttr($attr);

--- a/lib/jelix/plugins/formwidget/input_html/input_html.formwidget.php
+++ b/lib/jelix/plugins/formwidget/input_html/input_html.formwidget.php
@@ -92,6 +92,9 @@ class input_htmlFormWidget extends \jelix\forms\HtmlWidget\WidgetBase
         if ($maxl !== null) {
             $attr['maxlength'] = $maxl;
         }
+        if ($this->ctrl->placeholder != '') {
+            $attr['placeholder'] = $this->ctrl->placeholder;
+        }
         $attr['value'] = $this->getValue();
         $attr['type'] = 'text';
 

--- a/lib/jelix/plugins/formwidget/textarea_html/textarea_html.formwidget.php
+++ b/lib/jelix/plugins/formwidget/textarea_html/textarea_html.formwidget.php
@@ -55,6 +55,9 @@ class textarea_htmlFormWidget extends \jelix\forms\HtmlWidget\WidgetBase
         if (!isset($attr['cols'])) {
             $attr['cols'] = $this->ctrl->cols;
         }
+        if ($this->ctrl->placeholder != '') {
+            $attr['placeholder'] = $this->ctrl->placeholder;
+        }
 
         echo '<textarea';
         $this->_outputAttr($attr);

--- a/lib/jelix/plugins/formwidget/wikieditor_html/wikieditor_html.formwidget.php
+++ b/lib/jelix/plugins/formwidget/wikieditor_html/wikieditor_html.formwidget.php
@@ -64,6 +64,9 @@ class wikieditor_htmlFormWidget extends \jelix\forms\HtmlWidget\WidgetBase
         if (!isset($attr['cols'])) {
             $attr['cols'] = $this->ctrl->cols;
         }
+        if ($this->ctrl->placeholder != '') {
+            $attr['placeholder'] = $this->ctrl->placeholder;
+        }
 
         echo '<textarea';
         $this->_outputAttr($attr);

--- a/testapp/modules/testapp/forms/sample.form.xml
+++ b/testapp/modules/testapp/forms/sample.form.xml
@@ -7,6 +7,7 @@
 
         <input ref="nom" required="true">
             <label>Your name</label>
+            <placeholder locale='testapp~sample.form.input.nom.placeholder'/>
         </input>
 
         <input ref="prenom" defaultvalue="robert">
@@ -23,6 +24,7 @@
         </radiobuttons>
         <input ref="mail" type="email">
             <label>Your email</label>
+            <placeholder>email@foo.bar</placeholder>
         </input>
 
         <checkbox ref="geek">
@@ -60,15 +62,18 @@
       </listbox>
       <textarea ref="address">
           <label>Your address</label>
+          <placeholder locale='testapp~sample.form.textarea.address.placeholder'/>
       </textarea>
    </group>
 
   <htmleditor ref="description">
       <label>Description in html</label>
+      <placeholder>HTML editor</placeholder>
   </htmleditor>
    
   <wikieditor ref="wikicontent">
       <label>a wiki editor</label>
+      <placeholder>WIKI editor</placeholder>
   </wikieditor>
 
     <color ref="couleur">

--- a/testapp/modules/testapp/locales/en_US/sample.UTF-8.properties
+++ b/testapp/modules/testapp/locales/en_US/sample.UTF-8.properties
@@ -1,0 +1,2 @@
+form.input.nom.placeholder=Smith
+form.textarea.address.placeholder=Sample Adresse with special chars ''"  < &


### PR DESCRIPTION
Add placeholder  in `textarea`/`input `controls (textarea, input, wikieditor, htmleditor)
As label :  locale can be used

![Screenshot 2025-03-28 at 15-14-43 Form editing - Test App](https://github.com/user-attachments/assets/f6a8ec73-0d5c-4ca6-8c2e-ada6e8c59e65)

![Screenshot 2025-03-28 at 15-14-55 Form editing - Test App](https://github.com/user-attachments/assets/5b685de6-5c74-46cc-8d5b-2bc721c84705)
