### PR TITLE
remove warning for php 8.4 (in 1.8.x branch)

### DIFF
--- a/lib/jelix/init.php
+++ b/lib/jelix/init.php
@@ -38,7 +38,12 @@ define('LIB_PATH', dirname(JELIX_LIB_PATH).'/');
 
 define('BYTECODE_CACHE_EXISTS', function_exists('opcache_compile_file') || function_exists('apc_cache_info') || function_exists('eaccelerator_info') || function_exists('xcache_info'));
 
-error_reporting(E_ALL | E_STRICT);
+if (version_compare(phpversion(), '8.4.0', '<')) {
+    $err_level = E_ALL | E_STRICT;
+} else {
+    $err_level = E_ALL;
+}
+error_reporting($err_level);
 
 require JELIX_LIB_CORE_PATH.'jApp.class.php';
 


### PR DESCRIPTION
HP 8.4 deprecated E_STRICT. This PR removes a warning related to it.