### PR TITLE
fix IP calculation for private bloc 

### DIFF
--- a/lib/jelix/core/jRequest.class.php
+++ b/lib/jelix/core/jRequest.class.php
@@ -308,7 +308,7 @@ abstract class jRequest
                 $ip = trim($ip);
                 if (preg_match('/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/', $ip, $m)) {
                     if ($m[1] == '10' || $m[1] == '010'
-                        || ($m[1] == '172' && (intval($m[2]) & 240 == 16))
+                        || ($m[1] == '172' && ((intval($m[2]) & 240) == 16))
                         || ($m[1] == '192' && $m[2] == '168')) {
                         break;
                     } // stop at first private address. we just want the last public address


### PR DESCRIPTION
[operator precedence](https://www.php.net/manual/en/language.operators.precedence.php)

`(intval($m[2]) & 240 == 16)` means `(intval($m[2]) & (240 == 16)) ` and is never true `(intval($value) & 0 )` = 0 

exemple 
```
for($i = 0; $i < 255; $i++) { 
    if (intval($i) & 240 == 16) 
        echo $i." is ok";
}
```` 

Thanks to phpstan 